### PR TITLE
Disable placeholders inside arguments by default + itemhook palceholder support fix

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/action/ClickAction.java
+++ b/src/main/java/com/extendedclip/deluxemenus/action/ClickAction.java
@@ -108,7 +108,7 @@ public class ClickAction {
       return 0;
     }
 
-    final var parsed = Longs.tryParse(holder.setPlaceholders(delay));
+    final var parsed = Longs.tryParse(holder.setPlaceholdersAndArguments(delay));
     return parsed == null ? 0 : parsed;
   }
 
@@ -125,7 +125,7 @@ public class ClickAction {
       return true;
     }
 
-    final Double parsedChance = Doubles.tryParse(holder.setPlaceholders(this.chance));
+    final Double parsedChance = Doubles.tryParse(holder.setPlaceholdersAndArguments(this.chance));
     if (parsedChance == null) {
       return false;
     }

--- a/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
+++ b/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
@@ -46,8 +46,8 @@ public class ClickActionTask extends BukkitRunnable {
       return;
     }
 
-    final String executable = PlaceholderAPI.setPlaceholders((OfflinePlayer) player, exec);
     final MenuHolder holder = Menu.getMenuHolder(player);
+    final String executable = holder.setPlaceholdersAndArguments(exec);
 
     switch (actionType) {
       case META:

--- a/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
+++ b/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
@@ -8,12 +8,13 @@ import com.extendedclip.deluxemenus.utils.DebugLevel;
 import com.extendedclip.deluxemenus.utils.ExpUtils;
 import com.extendedclip.deluxemenus.utils.StringUtils;
 import com.extendedclip.deluxemenus.utils.VersionHelper;
+
+import java.util.Map;
+import java.util.UUID;
 import java.util.logging.Level;
-import me.clip.placeholderapi.PlaceholderAPI;
-import net.kyori.adventure.Adventure;
+
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
@@ -23,26 +24,36 @@ import org.jetbrains.annotations.NotNull;
 public class ClickActionTask extends BukkitRunnable {
 
   private final DeluxeMenus plugin;
-  private final MenuHolder holder;
+  private final UUID uuid;
   private final ActionType actionType;
   private final String exec;
+  // Ugly hack to get around the fact that arguments are not available at task execution time
+  private final Map<String, String> arguments;
 
   public ClickActionTask(
       @NotNull final DeluxeMenus plugin,
-      @NotNull final MenuHolder holder,
+      @NotNull final UUID uuid,
       @NotNull final ActionType actionType,
-      @NotNull final String exec
+      @NotNull final String exec,
+      @NotNull final Map<String, String> arguments
   ) {
     this.plugin = plugin;
-    this.holder = holder;
+    this.uuid = uuid;
     this.actionType = actionType;
     this.exec = exec;
+    this.arguments = arguments;
   }
 
   @Override
   public void run() {
-    final Player player = holder.getViewer();
-    final String executable = holder.setPlaceholdersAndArguments(exec);
+    final Player player = Bukkit.getPlayer(this.uuid);
+    if (player == null) {
+      return;
+    }
+
+    final MenuHolder holder = Menu.getMenuHolder(player);
+    final String executable = StringUtils.replacePlaceholdersAndArguments(this.exec, this.arguments, player);
+
 
     switch (actionType) {
       case META:

--- a/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
+++ b/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
@@ -23,313 +23,316 @@ import org.jetbrains.annotations.NotNull;
 
 public class ClickActionTask extends BukkitRunnable {
 
-  private final DeluxeMenus plugin;
-  private final UUID uuid;
-  private final ActionType actionType;
-  private final String exec;
-  // Ugly hack to get around the fact that arguments are not available at task execution time
-  private final Map<String, String> arguments;
+    private final DeluxeMenus plugin;
+    private final UUID uuid;
+    private final ActionType actionType;
+    private final String exec;
+    // Ugly hack to get around the fact that arguments are not available at task execution time
+    private final Map<String, String> arguments;
+    private final boolean parsePlaceholdersInArguments;
 
-  public ClickActionTask(
-      @NotNull final DeluxeMenus plugin,
-      @NotNull final UUID uuid,
-      @NotNull final ActionType actionType,
-      @NotNull final String exec,
-      @NotNull final Map<String, String> arguments
-  ) {
-    this.plugin = plugin;
-    this.uuid = uuid;
-    this.actionType = actionType;
-    this.exec = exec;
-    this.arguments = arguments;
-  }
-
-  @Override
-  public void run() {
-    final Player player = Bukkit.getPlayer(this.uuid);
-    if (player == null) {
-      return;
+    public ClickActionTask(
+            @NotNull final DeluxeMenus plugin,
+            @NotNull final UUID uuid,
+            @NotNull final ActionType actionType,
+            @NotNull final String exec,
+            @NotNull final Map<String, String> arguments,
+            final boolean parsePlaceholdersInArguments
+    ) {
+        this.plugin = plugin;
+        this.uuid = uuid;
+        this.actionType = actionType;
+        this.exec = exec;
+        this.arguments = arguments;
+        this.parsePlaceholdersInArguments = parsePlaceholdersInArguments;
     }
 
-    final MenuHolder holder = Menu.getMenuHolder(player);
-    final String executable = StringUtils.replacePlaceholdersAndArguments(this.exec, this.arguments, player, true);
-
-
-    switch (actionType) {
-      case META:
-        if (!VersionHelper.IS_PDC_VERSION || DeluxeMenus.getInstance().getPersistentMetaHandler() == null) {
-          DeluxeMenus.debug(DebugLevel.HIGHEST, Level.INFO, "Meta action not supported on this server version.");
-          break;
-        }
-        try {
-          final boolean result = DeluxeMenus.getInstance().getPersistentMetaHandler().setMeta(player, executable);
-          if (!result) {
-            DeluxeMenus.debug(DebugLevel.HIGHEST, Level.INFO, "Invalid meta action! Make sure you have the right syntax.");
-            break;
-          }
-        } catch (final NumberFormatException exception) {
-          DeluxeMenus.debug(DebugLevel.HIGHEST, Level.INFO, "Invalid integer value for meta action!");
-        }
-        break;
-
-      case PLAYER:
-        player.chat("/" + executable);
-        break;
-
-      case PLAYER_COMMAND_EVENT:
-        Bukkit.getPluginManager().callEvent(new PlayerCommandPreprocessEvent(player, "/" + executable));
-        break;
-
-      case PLACEHOLDER:
-        holder.setPlaceholders(executable);
-        break;
-
-      case CHAT:
-        player.chat(executable);
-        break;
-
-      case CONSOLE:
-        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), executable);
-        break;
-
-      case MINI_MESSAGE:
-        plugin.adventure().player(player).sendMessage(MiniMessage.miniMessage().deserialize(executable));
-        break;
-
-      case MINI_BROADCAST:
-        plugin.adventure().all().sendMessage(MiniMessage.miniMessage().deserialize(executable));
-        break;
-
-      case MESSAGE:
-        player.sendMessage(StringUtils.color(executable));
-        break;
-
-      case BROADCAST:
-        Bukkit.broadcastMessage(StringUtils.color(executable));
-        break;
-
-      case CLOSE:
-        Menu.closeMenu(player, true, true);
-        break;
-
-      case OPEN_GUI_MENU:
-      case OPEN_MENU:
-        final Menu menuToOpen = Menu.getMenu(executable);
-        if (menuToOpen == null) {
-          DeluxeMenus.debug(DebugLevel.HIGHEST, Level.WARNING, "Could not find and open menu " + executable);
-          break;
+    @Override
+    public void run() {
+        final Player player = Bukkit.getPlayer(this.uuid);
+        if (player == null) {
+            return;
         }
 
-        if (holder == null) {
-          menuToOpen.openMenu(player);
-          break;
-        }
+        final MenuHolder holder = Menu.getMenuHolder(player);
+        final String executable = StringUtils.replacePlaceholdersAndArguments(this.exec, this.arguments, player, this.parsePlaceholdersInArguments);
 
-        menuToOpen.openMenu(player, holder.getTypedArgs(), holder.getPlaceholderPlayer());
-        break;
-
-      case CONNECT:
-        DeluxeMenus.getInstance().connect(player, executable);
-        break;
-
-      case JSON_MESSAGE:
-        AdventureUtils.sendJson(player, executable);
-        break;
-
-      case JSON_BROADCAST:
-      case BROADCAST_JSON:
-        plugin.adventure().all().sendMessage(AdventureUtils.fromJson(executable));
-        break;
-
-      case REFRESH:
-        if (holder == null) {
-          DeluxeMenus.debug(
-              DebugLevel.HIGHEST,
-              Level.WARNING,
-              player.getName() + " does not have menu open! Nothing to refresh!"
-          );
-          break;
-        }
-
-        holder.refreshMenu();
-        break;
-
-      case TAKE_MONEY:
-        if (DeluxeMenus.getInstance().getVault() == null || !DeluxeMenus.getInstance().getVault().hooked()) {
-          DeluxeMenus.debug(DebugLevel.HIGHEST, Level.WARNING, "Vault not hooked! Cannot take money!");
-          break;
-        }
-
-        try {
-          DeluxeMenus.getInstance().getVault().takeMoney(player, Double.parseDouble(executable));
-        } catch (final NumberFormatException exception) {
-          DeluxeMenus.debug(
-              DebugLevel.HIGHEST,
-              Level.WARNING,
-              "Amount for take money action: " + executable + ", is not a valid number!"
-          );
-        }
-        break;
-
-      case GIVE_MONEY:
-        if (DeluxeMenus.getInstance().getVault() == null || !DeluxeMenus.getInstance().getVault().hooked()) {
-          DeluxeMenus.debug(DebugLevel.HIGHEST, Level.WARNING, "Vault not hooked! Cannot give money!");
-          break;
-        }
-
-        try {
-          DeluxeMenus.getInstance().getVault().giveMoney(player, Double.parseDouble(executable));
-        } catch (final NumberFormatException exception) {
-          DeluxeMenus.debug(
-              DebugLevel.HIGHEST,
-              Level.WARNING,
-              "Amount for give money action: " + executable + ", is not a valid number!"
-          );
-        }
-        break;
-
-      case TAKE_EXP:
-      case GIVE_EXP:
-        final String lowerCaseExecutable = executable.toLowerCase();
-
-        try {
-          if (Integer.parseInt(lowerCaseExecutable.replaceAll("l", "")) <= 0) break;
-
-          if (actionType == ActionType.TAKE_EXP) {
-              ExpUtils.setExp(player, "-" + lowerCaseExecutable);
-              break;
-          }
-
-          ExpUtils.setExp(player, lowerCaseExecutable);
-          break;
-
-        } catch (final NumberFormatException exception) {
-          if (actionType == ActionType.TAKE_EXP) {
-            DeluxeMenus.debug(
-                DebugLevel.HIGHEST,
-                Level.WARNING,
-                "Amount for take exp action: " + executable + ", is not a valid number!"
-            );
-            break;
-          }
-
-          DeluxeMenus.debug(
-              DebugLevel.HIGHEST,
-              Level.WARNING,
-              "Amount for give exp action: " + executable + ", is not a valid number!"
-          );
-          break;
-        }
-
-      case GIVE_PERM:
-        if (DeluxeMenus.getInstance().getVault() == null || !DeluxeMenus.getInstance().getVault().hooked()) {
-          DeluxeMenus.debug(
-              DebugLevel.HIGHEST,
-              Level.WARNING,
-              "Vault not hooked! Cannot give permission: " + executable + "!");
-          break;
-        }
-
-        DeluxeMenus.getInstance().getVault().givePermission(player, executable);
-        break;
-
-      case TAKE_PERM:
-        if (DeluxeMenus.getInstance().getVault() == null || !DeluxeMenus.getInstance().getVault().hooked()) {
-          DeluxeMenus.debug(
-              DebugLevel.HIGHEST,
-              Level.WARNING,
-              "Vault not hooked! Cannot take permission: " + executable + "!");
-          break;
-        }
-
-        DeluxeMenus.getInstance().getVault().takePermission(player, executable);
-        break;
-
-      case BROADCAST_SOUND:
-      case BROADCAST_WORLD_SOUND:
-      case PLAY_SOUND:
-        final Sound sound;
-        float volume = 1;
-        float pitch = 1;
-
-        if (!executable.contains(" ")) {
-          try {
-            sound = Sound.valueOf(executable.toUpperCase());
-          } catch (final IllegalArgumentException exception) {
-            DeluxeMenus.printStacktrace(
-                "Sound name given for sound action: " + executable + ", is not a valid sound!",
-                exception
-            );
-            break;
-          }
-        } else {
-          String[] parts = executable.split(" ", 3);
-
-          try {
-            sound = Sound.valueOf(parts[0].toUpperCase());
-          } catch (final IllegalArgumentException exception) {
-            DeluxeMenus.printStacktrace(
-                "Sound name given for sound action: " + parts[0] + ", is not a valid sound!",
-                exception
-            );
-            break;
-          }
-
-          if (parts.length == 3) {
-            try {
-              pitch = Float.parseFloat(parts[2]);
-            } catch (final NumberFormatException exception) {
-              DeluxeMenus.debug(
-                  DebugLevel.HIGHEST,
-                  Level.WARNING,
-                  "Pitch given for sound action: " + parts[2] + ", is not a valid number!"
-              );
-
-              DeluxeMenus.printStacktrace(
-                  "Pitch given for sound action: " + parts[2] + ", is not a valid number!",
-                  exception
-              );
-            }
-          }
-
-
-          try {
-            volume = Float.parseFloat(parts[1]);
-          } catch (final NumberFormatException exception) {
-            DeluxeMenus.debug(
-                DebugLevel.HIGHEST,
-                Level.WARNING,
-                "Volume given for sound action: " + parts[1] + ", is not a valid number!"
-            );
-
-            DeluxeMenus.printStacktrace(
-                "Volume given for sound action: " + parts[1] + ", is not a valid number!",
-                exception
-            );
-          }
-        }
 
         switch (actionType) {
-          case BROADCAST_SOUND:
-            for (final Player target : Bukkit.getOnlinePlayers()) {
-              target.playSound(target.getLocation(), sound, volume, pitch);
-            }
-            break;
+            case META:
+                if (!VersionHelper.IS_PDC_VERSION || DeluxeMenus.getInstance().getPersistentMetaHandler() == null) {
+                    DeluxeMenus.debug(DebugLevel.HIGHEST, Level.INFO, "Meta action not supported on this server version.");
+                    break;
+                }
+                try {
+                    final boolean result = DeluxeMenus.getInstance().getPersistentMetaHandler().setMeta(player, executable);
+                    if (!result) {
+                        DeluxeMenus.debug(DebugLevel.HIGHEST, Level.INFO, "Invalid meta action! Make sure you have the right syntax.");
+                        break;
+                    }
+                } catch (final NumberFormatException exception) {
+                    DeluxeMenus.debug(DebugLevel.HIGHEST, Level.INFO, "Invalid integer value for meta action!");
+                }
+                break;
 
-          case BROADCAST_WORLD_SOUND:
-            for (final Player target : player.getWorld().getPlayers()) {
-              target.playSound(target.getLocation(), sound, volume, pitch);
-            }
-            break;
+            case PLAYER:
+                player.chat("/" + executable);
+                break;
 
-          case PLAY_SOUND:
-            player.playSound(player.getLocation(), sound, volume, pitch);
-            break;
+            case PLAYER_COMMAND_EVENT:
+                Bukkit.getPluginManager().callEvent(new PlayerCommandPreprocessEvent(player, "/" + executable));
+                break;
+
+            case PLACEHOLDER:
+                holder.setPlaceholders(executable);
+                break;
+
+            case CHAT:
+                player.chat(executable);
+                break;
+
+            case CONSOLE:
+                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), executable);
+                break;
+
+            case MINI_MESSAGE:
+                plugin.adventure().player(player).sendMessage(MiniMessage.miniMessage().deserialize(executable));
+                break;
+
+            case MINI_BROADCAST:
+                plugin.adventure().all().sendMessage(MiniMessage.miniMessage().deserialize(executable));
+                break;
+
+            case MESSAGE:
+                player.sendMessage(StringUtils.color(executable));
+                break;
+
+            case BROADCAST:
+                Bukkit.broadcastMessage(StringUtils.color(executable));
+                break;
+
+            case CLOSE:
+                Menu.closeMenu(player, true, true);
+                break;
+
+            case OPEN_GUI_MENU:
+            case OPEN_MENU:
+                final Menu menuToOpen = Menu.getMenu(executable);
+                if (menuToOpen == null) {
+                    DeluxeMenus.debug(DebugLevel.HIGHEST, Level.WARNING, "Could not find and open menu " + executable);
+                    break;
+                }
+
+                if (holder == null) {
+                    menuToOpen.openMenu(player);
+                    break;
+                }
+
+                menuToOpen.openMenu(player, holder.getTypedArgs(), holder.getPlaceholderPlayer());
+                break;
+
+            case CONNECT:
+                DeluxeMenus.getInstance().connect(player, executable);
+                break;
+
+            case JSON_MESSAGE:
+                AdventureUtils.sendJson(player, executable);
+                break;
+
+            case JSON_BROADCAST:
+            case BROADCAST_JSON:
+                plugin.adventure().all().sendMessage(AdventureUtils.fromJson(executable));
+                break;
+
+            case REFRESH:
+                if (holder == null) {
+                    DeluxeMenus.debug(
+                            DebugLevel.HIGHEST,
+                            Level.WARNING,
+                            player.getName() + " does not have menu open! Nothing to refresh!"
+                    );
+                    break;
+                }
+
+                holder.refreshMenu();
+                break;
+
+            case TAKE_MONEY:
+                if (DeluxeMenus.getInstance().getVault() == null || !DeluxeMenus.getInstance().getVault().hooked()) {
+                    DeluxeMenus.debug(DebugLevel.HIGHEST, Level.WARNING, "Vault not hooked! Cannot take money!");
+                    break;
+                }
+
+                try {
+                    DeluxeMenus.getInstance().getVault().takeMoney(player, Double.parseDouble(executable));
+                } catch (final NumberFormatException exception) {
+                    DeluxeMenus.debug(
+                            DebugLevel.HIGHEST,
+                            Level.WARNING,
+                            "Amount for take money action: " + executable + ", is not a valid number!"
+                    );
+                }
+                break;
+
+            case GIVE_MONEY:
+                if (DeluxeMenus.getInstance().getVault() == null || !DeluxeMenus.getInstance().getVault().hooked()) {
+                    DeluxeMenus.debug(DebugLevel.HIGHEST, Level.WARNING, "Vault not hooked! Cannot give money!");
+                    break;
+                }
+
+                try {
+                    DeluxeMenus.getInstance().getVault().giveMoney(player, Double.parseDouble(executable));
+                } catch (final NumberFormatException exception) {
+                    DeluxeMenus.debug(
+                            DebugLevel.HIGHEST,
+                            Level.WARNING,
+                            "Amount for give money action: " + executable + ", is not a valid number!"
+                    );
+                }
+                break;
+
+            case TAKE_EXP:
+            case GIVE_EXP:
+                final String lowerCaseExecutable = executable.toLowerCase();
+
+                try {
+                    if (Integer.parseInt(lowerCaseExecutable.replaceAll("l", "")) <= 0) break;
+
+                    if (actionType == ActionType.TAKE_EXP) {
+                        ExpUtils.setExp(player, "-" + lowerCaseExecutable);
+                        break;
+                    }
+
+                    ExpUtils.setExp(player, lowerCaseExecutable);
+                    break;
+
+                } catch (final NumberFormatException exception) {
+                    if (actionType == ActionType.TAKE_EXP) {
+                        DeluxeMenus.debug(
+                                DebugLevel.HIGHEST,
+                                Level.WARNING,
+                                "Amount for take exp action: " + executable + ", is not a valid number!"
+                        );
+                        break;
+                    }
+
+                    DeluxeMenus.debug(
+                            DebugLevel.HIGHEST,
+                            Level.WARNING,
+                            "Amount for give exp action: " + executable + ", is not a valid number!"
+                    );
+                    break;
+                }
+
+            case GIVE_PERM:
+                if (DeluxeMenus.getInstance().getVault() == null || !DeluxeMenus.getInstance().getVault().hooked()) {
+                    DeluxeMenus.debug(
+                            DebugLevel.HIGHEST,
+                            Level.WARNING,
+                            "Vault not hooked! Cannot give permission: " + executable + "!");
+                    break;
+                }
+
+                DeluxeMenus.getInstance().getVault().givePermission(player, executable);
+                break;
+
+            case TAKE_PERM:
+                if (DeluxeMenus.getInstance().getVault() == null || !DeluxeMenus.getInstance().getVault().hooked()) {
+                    DeluxeMenus.debug(
+                            DebugLevel.HIGHEST,
+                            Level.WARNING,
+                            "Vault not hooked! Cannot take permission: " + executable + "!");
+                    break;
+                }
+
+                DeluxeMenus.getInstance().getVault().takePermission(player, executable);
+                break;
+
+            case BROADCAST_SOUND:
+            case BROADCAST_WORLD_SOUND:
+            case PLAY_SOUND:
+                final Sound sound;
+                float volume = 1;
+                float pitch = 1;
+
+                if (!executable.contains(" ")) {
+                    try {
+                        sound = Sound.valueOf(executable.toUpperCase());
+                    } catch (final IllegalArgumentException exception) {
+                        DeluxeMenus.printStacktrace(
+                                "Sound name given for sound action: " + executable + ", is not a valid sound!",
+                                exception
+                        );
+                        break;
+                    }
+                } else {
+                    String[] parts = executable.split(" ", 3);
+
+                    try {
+                        sound = Sound.valueOf(parts[0].toUpperCase());
+                    } catch (final IllegalArgumentException exception) {
+                        DeluxeMenus.printStacktrace(
+                                "Sound name given for sound action: " + parts[0] + ", is not a valid sound!",
+                                exception
+                        );
+                        break;
+                    }
+
+                    if (parts.length == 3) {
+                        try {
+                            pitch = Float.parseFloat(parts[2]);
+                        } catch (final NumberFormatException exception) {
+                            DeluxeMenus.debug(
+                                    DebugLevel.HIGHEST,
+                                    Level.WARNING,
+                                    "Pitch given for sound action: " + parts[2] + ", is not a valid number!"
+                            );
+
+                            DeluxeMenus.printStacktrace(
+                                    "Pitch given for sound action: " + parts[2] + ", is not a valid number!",
+                                    exception
+                            );
+                        }
+                    }
+
+
+                    try {
+                        volume = Float.parseFloat(parts[1]);
+                    } catch (final NumberFormatException exception) {
+                        DeluxeMenus.debug(
+                                DebugLevel.HIGHEST,
+                                Level.WARNING,
+                                "Volume given for sound action: " + parts[1] + ", is not a valid number!"
+                        );
+
+                        DeluxeMenus.printStacktrace(
+                                "Volume given for sound action: " + parts[1] + ", is not a valid number!",
+                                exception
+                        );
+                    }
+                }
+
+                switch (actionType) {
+                    case BROADCAST_SOUND:
+                        for (final Player target : Bukkit.getOnlinePlayers()) {
+                            target.playSound(target.getLocation(), sound, volume, pitch);
+                        }
+                        break;
+
+                    case BROADCAST_WORLD_SOUND:
+                        for (final Player target : player.getWorld().getPlayers()) {
+                            target.playSound(target.getLocation(), sound, volume, pitch);
+                        }
+                        break;
+
+                    case PLAY_SOUND:
+                        player.playSound(player.getLocation(), sound, volume, pitch);
+                        break;
+                }
+                break;
+
+            default:
+                break;
         }
-        break;
-
-      default:
-        break;
     }
-  }
 }

--- a/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
+++ b/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
@@ -52,7 +52,7 @@ public class ClickActionTask extends BukkitRunnable {
     }
 
     final MenuHolder holder = Menu.getMenuHolder(player);
-    final String executable = StringUtils.replacePlaceholdersAndArguments(this.exec, this.arguments, player);
+    final String executable = StringUtils.replacePlaceholdersAndArguments(this.exec, this.arguments, player, true);
 
 
     switch (actionType) {

--- a/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
+++ b/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
@@ -75,7 +75,7 @@ public class ClickActionTask extends BukkitRunnable {
         break;
 
       case PLACEHOLDER:
-        PlaceholderAPI.setPlaceholders(player, executable);
+        holder.setPlaceholders(executable);
         break;
 
       case CHAT:

--- a/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
+++ b/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
@@ -23,30 +23,25 @@ import org.jetbrains.annotations.NotNull;
 public class ClickActionTask extends BukkitRunnable {
 
   private final DeluxeMenus plugin;
-  private final String name;
+  private final MenuHolder holder;
   private final ActionType actionType;
   private final String exec;
 
   public ClickActionTask(
       @NotNull final DeluxeMenus plugin,
-      @NotNull final String name,
+      @NotNull final MenuHolder holder,
       @NotNull final ActionType actionType,
       @NotNull final String exec
   ) {
     this.plugin = plugin;
-    this.name = name;
+    this.holder = holder;
     this.actionType = actionType;
     this.exec = exec;
   }
 
   @Override
   public void run() {
-    final Player player = Bukkit.getServer().getPlayerExact(name);
-    if (player == null) {
-      return;
-    }
-
-    final MenuHolder holder = Menu.getMenuHolder(player);
+    final Player player = holder.getViewer();
     final String executable = holder.setPlaceholdersAndArguments(exec);
 
     switch (actionType) {

--- a/src/main/java/com/extendedclip/deluxemenus/commands/DeluxeMenusCommands.java
+++ b/src/main/java/com/extendedclip/deluxemenus/commands/DeluxeMenusCommands.java
@@ -178,7 +178,8 @@ public class DeluxeMenusCommands implements CommandExecutor {
               target.getUniqueId(),
               action.getType(),
               action.getExecutable(),
-              holder.getTypedArgs()
+              holder.getTypedArgs(),
+              true
       );
 
       if (action.hasDelay()) {

--- a/src/main/java/com/extendedclip/deluxemenus/commands/DeluxeMenusCommands.java
+++ b/src/main/java/com/extendedclip/deluxemenus/commands/DeluxeMenusCommands.java
@@ -173,13 +173,15 @@ public class DeluxeMenusCommands implements CommandExecutor {
         return true;
       }
 
+      final ClickActionTask actionTask = new ClickActionTask(
+              plugin,
+              holder,
+              action.getType(),
+              action.getExecutable()
+      );
+
       if (action.hasDelay()) {
-        new ClickActionTask(
-            plugin,
-            target.getName(),
-            action.getType(),
-            action.getExecutable()
-        ).runTaskLater(plugin, action.getDelay(holder));
+        actionTask.runTaskLater(plugin, action.getDelay(holder));
 
         plugin.sms(
             sender,
@@ -189,12 +191,7 @@ public class DeluxeMenusCommands implements CommandExecutor {
         return true;
       }
 
-      new ClickActionTask(
-          plugin,
-          target.getName(),
-          action.getType(),
-          action.getExecutable()
-      ).runTask(plugin);
+      actionTask.runTask(plugin);
 
       plugin.sms(
           sender,

--- a/src/main/java/com/extendedclip/deluxemenus/commands/DeluxeMenusCommands.java
+++ b/src/main/java/com/extendedclip/deluxemenus/commands/DeluxeMenusCommands.java
@@ -175,9 +175,10 @@ public class DeluxeMenusCommands implements CommandExecutor {
 
       final ClickActionTask actionTask = new ClickActionTask(
               plugin,
-              holder,
+              target.getUniqueId(),
               action.getType(),
-              action.getExecutable()
+              action.getExecutable(),
+              holder.getTypedArgs()
       );
 
       if (action.hasDelay()) {

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -1477,9 +1477,10 @@ public class DeluxeMenusConfig {
 
             final ClickActionTask actionTask = new ClickActionTask(
                     plugin,
-                    holder,
+                    holder.getViewer().getUniqueId(),
                     action.getType(),
-                    action.getExecutable()
+                    holder.setPlaceholdersAndArguments(action.getExecutable()),
+                    holder.getTypedArgs()
             );
 
             if (action.hasDelay()) {

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -613,10 +613,12 @@ public class DeluxeMenusConfig {
       return;
     }
 
+    final boolean argumentsSupportPlaceholders = c.getBoolean(pre + "arguments_support_placeholders", false);
+
     Menu menu;
 
     if (openCommands.isEmpty()) {
-      menu = new Menu(key, title, items, size);
+      menu = new Menu(key, title, items, size, argumentsSupportPlaceholders);
     } else {
       boolean registerCommand = c.getBoolean(pre + "register_command", false);
       List<String> args = null;
@@ -628,7 +630,7 @@ public class DeluxeMenusConfig {
           args = Collections.singletonList(c.getString(pre + "args"));
         }
       }
-      menu = new Menu(key, title, items, size, openCommands, registerCommand, args);
+      menu = new Menu(key, title, items, size, openCommands, registerCommand, args, argumentsSupportPlaceholders);
       menu.setArgUsageMessage(c.getString(pre + "args_usage_message", null));
     }
 

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -1475,22 +1475,19 @@ public class DeluxeMenusConfig {
               continue;
             }
 
+            final ClickActionTask actionTask = new ClickActionTask(
+                    plugin,
+                    holder.getViewer().getName(),
+                    action.getType(),
+                    action.getExecutable()
+            );
+
             if (action.hasDelay()) {
-              new ClickActionTask(
-                  plugin,
-                  holder.getViewer().getName(),
-                  action.getType(),
-                  holder.setArguments(action.getExecutable())
-              ).runTaskLater(plugin, action.getDelay(holder));
+              actionTask.runTaskLater(plugin, action.getDelay(holder));
               continue;
             }
 
-            new ClickActionTask(
-                plugin,
-                holder.getViewer().getName(),
-                action.getType(),
-                holder.setArguments(action.getExecutable())
-            ).runTask(plugin);
+            actionTask.runTask(plugin);
           }
         }
       };

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -1477,7 +1477,7 @@ public class DeluxeMenusConfig {
 
             final ClickActionTask actionTask = new ClickActionTask(
                     plugin,
-                    holder.getViewer().getName(),
+                    holder,
                     action.getType(),
                     action.getExecutable()
             );

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -1483,8 +1483,9 @@ public class DeluxeMenusConfig {
                     plugin,
                     holder.getViewer().getUniqueId(),
                     action.getType(),
-                    holder.setPlaceholdersAndArguments(action.getExecutable()),
-                    holder.getTypedArgs()
+                    action.getExecutable(),
+                    holder.getTypedArgs(),
+                    holder.parsePlaceholdersInArguments()
             );
 
             if (action.hasDelay()) {

--- a/src/main/java/com/extendedclip/deluxemenus/menu/Menu.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/Menu.java
@@ -47,9 +47,10 @@ public class Menu extends Command {
   // args
   private List<String> args;
   private String argUsageMessage;
+  private boolean parsePlaceholdersInArguments;
 
   public Menu(String menuName, String menuTitle, Map<Integer, TreeMap<Integer, MenuItem>> items,
-      int size, List<String> menuCommands, boolean registerCommand, List<String> args) {
+      int size, List<String> menuCommands, boolean registerCommand, List<String> args, boolean parsePlaceholdersInArguments) {
     super(menuCommands.get(0));
     this.menuName = menuName;
     this.menuTitle = StringUtils.color(menuTitle);
@@ -58,6 +59,7 @@ public class Menu extends Command {
     this.menuCommands = menuCommands;
     this.registersCommand = registerCommand;
     this.args = args;
+    this.parsePlaceholdersInArguments = parsePlaceholdersInArguments;
     if (registerCommand) {
       if (menuCommands.size() > 1) {
         this.setAliases(menuCommands.subList(1, menuCommands.size()));
@@ -68,12 +70,13 @@ public class Menu extends Command {
   }
 
   public Menu(String menuName, String menuTitle, Map<Integer, TreeMap<Integer, MenuItem>> items,
-      int size) {
+      int size, boolean parsePlaceholdersInArguments) {
     super(menuName);
     this.menuName = menuName;
     this.menuTitle = StringUtils.color(menuTitle);
     this.items = items;
     this.size = size;
+    this.parsePlaceholdersInArguments = parsePlaceholdersInArguments;
     menus.put(this.menuName, this);
   }
 
@@ -541,5 +544,13 @@ public class Menu extends Command {
 
   public void setArgUsageMessage(String argUsageMessage) {
     this.argUsageMessage = argUsageMessage;
+  }
+
+  public void parsePlaceholdersInArguments(final boolean parsePlaceholdersInArguments) {
+    this.parsePlaceholdersInArguments = parsePlaceholdersInArguments;
+  }
+
+  public boolean parsePlaceholdersInArguments() {
+    return parsePlaceholdersInArguments;
   }
 }

--- a/src/main/java/com/extendedclip/deluxemenus/menu/Menu.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/Menu.java
@@ -379,6 +379,7 @@ public class Menu extends Command {
       holder.setPlaceholderPlayer(placeholderPlayer);
     }
     holder.setTypedArgs(args);
+    holder.parsePlaceholdersInArguments(this.parsePlaceholdersInArguments);
 
     if (!this.handleArgRequirements(holder)) {
       return;
@@ -434,7 +435,7 @@ public class Menu extends Command {
         this.openHandler.onClick(holder);
       }
 
-      String title = StringUtils.color(holder.setPlaceholders(this.menuTitle));
+      String title = StringUtils.color(holder.setPlaceholdersAndArguments(this.menuTitle));
 
       Inventory inventory;
 

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
@@ -29,6 +29,7 @@ public class MenuHolder implements InventoryHolder {
   private BukkitTask updateTask = null;
   private Inventory inventory;
   private boolean updating;
+  private boolean parsePlaceholdersInArguments;
   private Map<String, String> typedArgs;
 
   public MenuHolder(Player viewer) {
@@ -89,17 +90,21 @@ public class MenuHolder implements InventoryHolder {
   }
 
   public String setPlaceholders(String string) {
-    if (this.typedArgs == null || this.typedArgs.isEmpty()) {
-      if (placeholderPlayer != null) return PlaceholderAPI.setPlaceholders((OfflinePlayer) placeholderPlayer, string);
-      else return this.getViewer() == null ? string
-          : PlaceholderAPI.setPlaceholders((OfflinePlayer) this.getViewer(), string);
+    if (this.parsePlaceholdersInArguments) {
+      string = setArguments(string);
     }
-    for (Entry<String, String> entry : typedArgs.entrySet()) {
-      string = string.replace("{" + entry.getKey() + "}", entry.getValue());
+
+    if (placeholderPlayer != null) {
+      string = PlaceholderAPI.setPlaceholders((OfflinePlayer) placeholderPlayer, string);
+    } else if (this.getViewer() != null) {
+      string = PlaceholderAPI.setPlaceholders((OfflinePlayer) this.getViewer(), string);
     }
-    if (placeholderPlayer != null) return PlaceholderAPI.setPlaceholders((OfflinePlayer) placeholderPlayer, string);
-    else return this.getViewer() == null ? string
-        : PlaceholderAPI.setPlaceholders((OfflinePlayer) this.getViewer(), string);
+
+    if (!this.parsePlaceholdersInArguments) {
+      string = setArguments(string);
+    }
+
+    return string;
   }
 
   public String setArguments(String string) {
@@ -302,6 +307,13 @@ public class MenuHolder implements InventoryHolder {
 
   public void setTypedArgs(Map<String, String> typedArgs) {
     this.typedArgs = typedArgs;
+  }
+
+  public void parsePlaceholdersInArguments(final boolean parsePlaceholdersInArguments) {
+    this.parsePlaceholdersInArguments = parsePlaceholdersInArguments;
+  }
+  public boolean parsePlaceholdersInArguments() {
+    return parsePlaceholdersInArguments;
   }
 
   public void setPlaceholderPlayer(Player placeholderPlayer) {

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
@@ -2,6 +2,7 @@ package com.extendedclip.deluxemenus.menu;
 
 import com.extendedclip.deluxemenus.DeluxeMenus;
 import com.extendedclip.deluxemenus.utils.StringUtils;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -9,6 +10,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
+
 import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
@@ -19,308 +21,309 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
 
 public class MenuHolder implements InventoryHolder {
 
-  private final Player viewer;
-  private Player placeholderPlayer;
-  private String menuName;
-  private Set<MenuItem> activeItems;
-  private BukkitTask updateTask = null;
-  private Inventory inventory;
-  private boolean updating;
-  private boolean parsePlaceholdersInArguments;
-  private Map<String, String> typedArgs;
+    private final Player viewer;
+    private Player placeholderPlayer;
+    private String menuName;
+    private Set<MenuItem> activeItems;
+    private BukkitTask updateTask = null;
+    private Inventory inventory;
+    private boolean updating;
+    private boolean parsePlaceholdersInArguments;
+    private Map<String, String> typedArgs;
 
-  public MenuHolder(Player viewer) {
-    this.viewer = viewer;
-  }
-
-  public MenuHolder(Player viewer, String menuName,
-      Set<MenuItem> activeItems, Inventory inventory) {
-    this.viewer = viewer;
-    this.menuName = menuName;
-    this.activeItems = activeItems;
-    this.inventory = inventory;
-  }
-
-  public String getViewerName() {
-    return viewer.getName();
-  }
-
-  public BukkitTask getUpdateTask() {
-    return updateTask;
-  }
-
-  public Player getViewer() {
-    return viewer;
-  }
-
-  public String getMenuName() {
-    return menuName;
-  }
-
-  public void setMenuName(String menuName) {
-    this.menuName = menuName;
-  }
-
-  public Set<MenuItem> getActiveItems() {
-    return activeItems;
-  }
-
-  public void setActiveItems(Set<MenuItem> items) {
-    this.activeItems = items;
-  }
-
-  public MenuHolder getHolder() {
-    return this;
-  }
-
-  public MenuItem getItem(int slot) {
-    for (MenuItem item : activeItems) {
-      if (item.options().slot() == slot) {
-        return item;
-      }
+    public MenuHolder(Player viewer) {
+        this.viewer = viewer;
     }
-    return null;
-  }
 
-  public Menu getMenu() {
-    return Menu.getMenu(menuName);
-  }
+    public MenuHolder(Player viewer, String menuName,
+                      Set<MenuItem> activeItems, Inventory inventory) {
+        this.viewer = viewer;
+        this.menuName = menuName;
+        this.activeItems = activeItems;
+        this.inventory = inventory;
+    }
 
-    public String setPlaceholders(String string) {
-        if (this.parsePlaceholdersInArguments) {
-            string = setArguments(string);
+    public String getViewerName() {
+        return viewer.getName();
+    }
+
+    public BukkitTask getUpdateTask() {
+        return updateTask;
+    }
+
+    public Player getViewer() {
+        return viewer;
+    }
+
+    public String getMenuName() {
+        return menuName;
+    }
+
+    public void setMenuName(String menuName) {
+        this.menuName = menuName;
+    }
+
+    public Set<MenuItem> getActiveItems() {
+        return activeItems;
+    }
+
+    public void setActiveItems(Set<MenuItem> items) {
+        this.activeItems = items;
+    }
+
+    public MenuHolder getHolder() {
+        return this;
+    }
+
+    public MenuItem getItem(int slot) {
+        for (MenuItem item : activeItems) {
+            if (item.options().slot() == slot) {
+                return item;
+            }
         }
+        return null;
+    }
 
+    public Menu getMenu() {
+        return Menu.getMenu(menuName);
+    }
+
+    public @NotNull String setPlaceholdersAndArguments(final @NotNull String string) {
+        return setArguments(setPlaceholders(string));
+    }
+
+    private @NotNull String setPlaceholders(final @NotNull String string) {
         if (placeholderPlayer != null) {
-            string = PlaceholderAPI.setPlaceholders((OfflinePlayer) placeholderPlayer, string);
+            return PlaceholderAPI.setPlaceholders((OfflinePlayer) placeholderPlayer, string);
         } else if (this.getViewer() != null) {
-            string = PlaceholderAPI.setPlaceholders((OfflinePlayer) this.getViewer(), string);
-        }
-
-        if (!this.parsePlaceholdersInArguments) {
-            string = setArguments(string);
+            return PlaceholderAPI.setPlaceholders((OfflinePlayer) this.getViewer(), string);
         }
 
         return string;
     }
 
-  public String setArguments(String string) {
-    if (this.typedArgs == null || this.typedArgs.isEmpty()) {
-      return string;
-    }
-    for (Entry<String, String> entry : this.typedArgs.entrySet()) {
-      string = string.replace("{" + entry.getKey() + "}", entry.getValue());
-    }
-    return string;
-  }
+    private @NotNull String setArguments(@NotNull String string) {
+        if (this.typedArgs == null || this.typedArgs.isEmpty()) {
+            return string;
+        }
 
-  public void refreshMenu() {
+        for (final Entry<String, String> entry : this.typedArgs.entrySet()) {
+            final String value = this.parsePlaceholdersInArguments ? setPlaceholders(entry.getValue()) : entry.getValue();
+            string = string.replace("{" + entry.getKey() + "}", value);
+        }
 
-    Menu menu = getMenu();
-
-    if (menu == null || menu.getMenuItems() == null || menu.getMenuItems().size() <= 0) {
-      return;
+        return string;
     }
 
-    setUpdating(true);
+    public void refreshMenu() {
 
-    stopPlaceholderUpdate();
+        Menu menu = getMenu();
 
-    Bukkit.getScheduler().runTaskAsynchronously(DeluxeMenus.getInstance(), () -> {
-
-      final Set<MenuItem> active = new HashSet<>();
-
-      for (int i = 0; i < getInventory().getSize(); i++) {
-        TreeMap<Integer, MenuItem> e = menu.getMenuItems().get(i);
-
-        if (e == null) {
-          getInventory().setItem(i, null);
-          continue;
+        if (menu == null || menu.getMenuItems() == null || menu.getMenuItems().size() <= 0) {
+            return;
         }
 
-        boolean m = false;
-        for (MenuItem item : e.values()) {
+        setUpdating(true);
 
-          if (item.options().viewRequirements().isPresent()) {
+        stopPlaceholderUpdate();
 
-            if (item.options().viewRequirements().get().evaluate(this)) {
-              m = true;
-              active.add(item);
-              break;
-            }
-          } else {
-            m = true;
-            active.add(item);
-            break;
-          }
-        }
+        Bukkit.getScheduler().runTaskAsynchronously(DeluxeMenus.getInstance(), () -> {
 
-        if (!m) {
-          getInventory().setItem(i, null);
-        }
-      }
+            final Set<MenuItem> active = new HashSet<>();
 
-      if (active.isEmpty()) {
-        Menu.closeMenu(getViewer(), true);
-      }
+            for (int i = 0; i < getInventory().getSize(); i++) {
+                TreeMap<Integer, MenuItem> e = menu.getMenuItems().get(i);
 
-      Bukkit.getScheduler().runTask(DeluxeMenus.getInstance(), () -> {
-
-        boolean update = false;
-
-        for (MenuItem item : active) {
-
-          ItemStack iStack = item.getItemStack(this);
-
-          int slot = item.options().slot();
-
-          if (slot >= menu.getSize()) {
-            continue;
-          }
-
-          if (item.options().updatePlaceholders()) {
-            update = true;
-          }
-
-          getInventory().setItem(item.options().slot(), iStack);
-        }
-
-        setActiveItems(active);
-
-        if (update) {
-          startUpdatePlaceholdersTask();
-        }
-
-        setUpdating(false);
-      });
-    });
-  }
-
-  public void stopPlaceholderUpdate() {
-    if (updateTask != null) {
-      try {
-        updateTask.cancel();
-      } catch (Exception ignored) {
-      }
-      updateTask = null;
-    }
-  }
-
-  public void startUpdatePlaceholdersTask() {
-
-    if (updateTask != null) {
-      stopPlaceholderUpdate();
-    }
-
-    updateTask = new BukkitRunnable() {
-
-      @Override
-      public void run() {
-
-        if (updating) {
-          return;
-        }
-
-        Set<MenuItem> items = getActiveItems();
-
-        if (items == null) {
-          return;
-        }
-
-        for (MenuItem item : items) {
-
-          if (item.options().updatePlaceholders()) {
-
-            ItemStack i = inventory.getItem(item.options().slot());
-
-            if (i == null) {
-              continue;
-            }
-
-            int amt = i.getAmount();
-
-            if (item.options().dynamicAmount().isPresent()) {
-              try {
-               amt = Integer.parseInt(setPlaceholders(item.options().dynamicAmount().get()));
-                if (amt <= 0) {
-                  amt = 1;
+                if (e == null) {
+                    getInventory().setItem(i, null);
+                    continue;
                 }
-              } catch (Exception exception) {
-                DeluxeMenus.printStacktrace(
-                    "Something went wrong while updating item in slot " + item.options().slot() +
-                        ". Invalid dynamic amount: " + setPlaceholders(item.options().dynamicAmount().get()),
-                    exception
-                );
-              }
+
+                boolean m = false;
+                for (MenuItem item : e.values()) {
+
+                    if (item.options().viewRequirements().isPresent()) {
+
+                        if (item.options().viewRequirements().get().evaluate(this)) {
+                            m = true;
+                            active.add(item);
+                            break;
+                        }
+                    } else {
+                        m = true;
+                        active.add(item);
+                        break;
+                    }
+                }
+
+                if (!m) {
+                    getInventory().setItem(i, null);
+                }
             }
 
-            ItemMeta meta = i.getItemMeta();
-
-            if (item.options().displayNameHasPlaceholders() && item.options().displayName().isPresent()) {
-              meta.setDisplayName(StringUtils.color(setPlaceholders(item.options().displayName().get())));
+            if (active.isEmpty()) {
+                Menu.closeMenu(getViewer(), true);
             }
 
-            if (item.options().loreHasPlaceholders()) {
+            Bukkit.getScheduler().runTask(DeluxeMenus.getInstance(), () -> {
 
-              List<String> updated = new ArrayList<>();
+                boolean update = false;
 
-              for (String line : item.options().lore()) {
-                updated.add(StringUtils
-                    .color(setPlaceholders(line)));
-              }
-              meta.setLore(updated);
+                for (MenuItem item : active) {
+
+                    ItemStack iStack = item.getItemStack(this);
+
+                    int slot = item.options().slot();
+
+                    if (slot >= menu.getSize()) {
+                        continue;
+                    }
+
+                    if (item.options().updatePlaceholders()) {
+                        update = true;
+                    }
+
+                    getInventory().setItem(item.options().slot(), iStack);
+                }
+
+                setActiveItems(active);
+
+                if (update) {
+                    startUpdatePlaceholdersTask();
+                }
+
+                setUpdating(false);
+            });
+        });
+    }
+
+    public void stopPlaceholderUpdate() {
+        if (updateTask != null) {
+            try {
+                updateTask.cancel();
+            } catch (Exception ignored) {
             }
-
-            i.setItemMeta(meta);
-            i.setAmount(amt);
-          }
+            updateTask = null;
         }
-      }
+    }
 
-    }.runTaskTimerAsynchronously(DeluxeMenus.getInstance(), 20L,
-        20L * Menu.getMenu(menuName).getUpdateInterval());
-  }
+    public void startUpdatePlaceholdersTask() {
 
-  public boolean isUpdating() {
-    return updating;
-  }
+        if (updateTask != null) {
+            stopPlaceholderUpdate();
+        }
 
-  public void setUpdating(boolean updating) {
-    this.updating = updating;
-  }
+        updateTask = new BukkitRunnable() {
 
-  @Override
-  public Inventory getInventory() {
-    return this.inventory;
-  }
+            @Override
+            public void run() {
 
-  public void setInventory(Inventory i) {
-    this.inventory = i;
-  }
+                if (updating) {
+                    return;
+                }
 
-  public Map<String, String> getTypedArgs() {
-    return typedArgs;
-  }
+                Set<MenuItem> items = getActiveItems();
 
-  public void setTypedArgs(Map<String, String> typedArgs) {
-    this.typedArgs = typedArgs;
-  }
+                if (items == null) {
+                    return;
+                }
 
-  public void parsePlaceholdersInArguments(final boolean parsePlaceholdersInArguments) {
-    this.parsePlaceholdersInArguments = parsePlaceholdersInArguments;
-  }
-  public boolean parsePlaceholdersInArguments() {
-    return parsePlaceholdersInArguments;
-  }
+                for (MenuItem item : items) {
 
-  public void setPlaceholderPlayer(Player placeholderPlayer) {
-    this.placeholderPlayer = placeholderPlayer;
-  }
+                    if (item.options().updatePlaceholders()) {
 
-  public Player getPlaceholderPlayer() {
-    return placeholderPlayer;
-  }
+                        ItemStack i = inventory.getItem(item.options().slot());
+
+                        if (i == null) {
+                            continue;
+                        }
+
+                        int amt = i.getAmount();
+
+                        if (item.options().dynamicAmount().isPresent()) {
+                            try {
+                                amt = Integer.parseInt(setPlaceholdersAndArguments(item.options().dynamicAmount().get()));
+                                if (amt <= 0) {
+                                    amt = 1;
+                                }
+                            } catch (Exception exception) {
+                                DeluxeMenus.printStacktrace(
+                                        "Something went wrong while updating item in slot " + item.options().slot() +
+                                                ". Invalid dynamic amount: " + setPlaceholdersAndArguments(item.options().dynamicAmount().get()),
+                                        exception
+                                );
+                            }
+                        }
+
+                        ItemMeta meta = i.getItemMeta();
+
+                        if (item.options().displayNameHasPlaceholders() && item.options().displayName().isPresent()) {
+                            meta.setDisplayName(StringUtils.color(setPlaceholdersAndArguments(item.options().displayName().get())));
+                        }
+
+                        if (item.options().loreHasPlaceholders()) {
+
+                            List<String> updated = new ArrayList<>();
+
+                            for (String line : item.options().lore()) {
+                                updated.add(StringUtils
+                                        .color(setPlaceholdersAndArguments(line)));
+                            }
+                            meta.setLore(updated);
+                        }
+
+                        i.setItemMeta(meta);
+                        i.setAmount(amt);
+                    }
+                }
+            }
+
+        }.runTaskTimerAsynchronously(DeluxeMenus.getInstance(), 20L,
+                20L * Menu.getMenu(menuName).getUpdateInterval());
+    }
+
+    public boolean isUpdating() {
+        return updating;
+    }
+
+    public void setUpdating(boolean updating) {
+        this.updating = updating;
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return this.inventory;
+    }
+
+    public void setInventory(Inventory i) {
+        this.inventory = i;
+    }
+
+    public Map<String, String> getTypedArgs() {
+        return typedArgs;
+    }
+
+    public void setTypedArgs(Map<String, String> typedArgs) {
+        this.typedArgs = typedArgs;
+    }
+
+    public void parsePlaceholdersInArguments(final boolean parsePlaceholdersInArguments) {
+        this.parsePlaceholdersInArguments = parsePlaceholdersInArguments;
+    }
+
+    public boolean parsePlaceholdersInArguments() {
+        return parsePlaceholdersInArguments;
+    }
+
+    public void setPlaceholderPlayer(Player placeholderPlayer) {
+        this.placeholderPlayer = placeholderPlayer;
+    }
+
+    public Player getPlaceholderPlayer() {
+        return placeholderPlayer;
+    }
 }

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
@@ -2,18 +2,7 @@ package com.extendedclip.deluxemenus.menu;
 
 import com.extendedclip.deluxemenus.DeluxeMenus;
 import com.extendedclip.deluxemenus.utils.StringUtils;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeMap;
-
-import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
@@ -22,6 +11,13 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
 public class MenuHolder implements InventoryHolder {
 
@@ -97,26 +93,22 @@ public class MenuHolder implements InventoryHolder {
     }
 
     public @NotNull String setPlaceholders(final @NotNull String string) {
-        if (placeholderPlayer != null) {
-            return PlaceholderAPI.setPlaceholders((OfflinePlayer) placeholderPlayer, string);
-        } else if (this.getViewer() != null) {
-            return PlaceholderAPI.setPlaceholders((OfflinePlayer) this.getViewer(), string);
-        }
-
-        return string;
-    }
-
-    public @NotNull String setArguments(@NotNull String string) {
-        if (this.typedArgs == null || this.typedArgs.isEmpty()) {
+        final Player player = this.placeholderPlayer != null ? this.placeholderPlayer : this.getViewer();
+        if (player == null) {
             return string;
         }
 
-        for (final Entry<String, String> entry : this.typedArgs.entrySet()) {
-            final String value = this.parsePlaceholdersInArguments ? setPlaceholders(entry.getValue()) : entry.getValue();
-            string = string.replace("{" + entry.getKey() + "}", value);
-        }
+        return StringUtils.replacePlaceholders(string, player);
+    }
 
-        return string;
+    public @NotNull String setArguments(final @NotNull String string) {
+        final Player player = this.placeholderPlayer != null ? this.placeholderPlayer : this.getViewer();
+
+        return StringUtils.replaceArguments(
+                string,
+                this.typedArgs,
+                player
+        );
     }
 
     public void refreshMenu() {

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
@@ -107,7 +107,8 @@ public class MenuHolder implements InventoryHolder {
         return StringUtils.replaceArguments(
                 string,
                 this.typedArgs,
-                player
+                player,
+                this.parsePlaceholdersInArguments
         );
     }
 

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
@@ -96,7 +96,7 @@ public class MenuHolder implements InventoryHolder {
         return setArguments(setPlaceholders(string));
     }
 
-    private @NotNull String setPlaceholders(final @NotNull String string) {
+    public @NotNull String setPlaceholders(final @NotNull String string) {
         if (placeholderPlayer != null) {
             return PlaceholderAPI.setPlaceholders((OfflinePlayer) placeholderPlayer, string);
         } else if (this.getViewer() != null) {
@@ -106,7 +106,7 @@ public class MenuHolder implements InventoryHolder {
         return string;
     }
 
-    private @NotNull String setArguments(@NotNull String string) {
+    public @NotNull String setArguments(@NotNull String string) {
         if (this.typedArgs == null || this.typedArgs.isEmpty()) {
             return string;
         }

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -84,7 +84,10 @@ public class MenuItem {
 
         if (ItemUtils.isWaterBottle(stringMaterial)) {
             itemStack = ItemUtils.createWaterBottles(amount);
-        } else if (itemStack == null) {
+        }
+
+        // The item is neither a water bottle nor plugin hook item
+        if (itemStack == null) {
             final Material material = Material.getMaterial(stringMaterial.toUpperCase(Locale.ROOT));
             if (material == null) {
                 DeluxeMenus.debug(

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -56,7 +56,7 @@ public class MenuItem {
         String lowercaseStringMaterial = stringMaterial.toLowerCase(Locale.ROOT);
 
         if (ItemUtils.isPlaceholderMaterial(lowercaseStringMaterial)) {
-            stringMaterial = holder.setPlaceholders(stringMaterial.substring(PLACEHOLDER_PREFIX.length()));
+            stringMaterial = holder.setPlaceholdersAndArguments(stringMaterial.substring(PLACEHOLDER_PREFIX.length()));
             lowercaseStringMaterial = stringMaterial.toLowerCase(Locale.ENGLISH);
         }
 
@@ -75,16 +75,16 @@ public class MenuItem {
         final int temporaryAmount = amount;
 
         if (isHeadItem(lowercaseStringMaterial) && this.options.headType().isPresent()) {
-            itemStack = getItemFromHook(this.options.headType().get().getHookName(), holder.setPlaceholders(stringMaterial.substring(this.options.headType().get().getPrefix().length())))
+            itemStack = getItemFromHook(this.options.headType().get().getHookName(), holder.setPlaceholdersAndArguments(stringMaterial.substring(this.options.headType().get().getPrefix().length())))
                     .orElseGet(() -> DeluxeMenus.getInstance().getHead().clone());
         } else if (ItemUtils.isItemsAdderItem(lowercaseStringMaterial)) {
-            itemStack = getItemFromHook("itemsadder", holder.setPlaceholders(stringMaterial.substring(ITEMSADDER_PREFIX.length())))
+            itemStack = getItemFromHook("itemsadder", holder.setPlaceholdersAndArguments(stringMaterial.substring(ITEMSADDER_PREFIX.length())))
                     .orElseGet(() -> new ItemStack(Material.STONE, temporaryAmount));
         } else if (ItemUtils.isOraxenItem(lowercaseStringMaterial)) {
-            itemStack = getItemFromHook("oraxen", holder.setPlaceholders(stringMaterial.substring(ORAXEN_PREFIX.length())))
+            itemStack = getItemFromHook("oraxen", holder.setPlaceholdersAndArguments(stringMaterial.substring(ORAXEN_PREFIX.length())))
                     .orElseGet(() -> new ItemStack(Material.STONE, temporaryAmount));
         } else if (ItemUtils.isMMOItemsItem(lowercaseStringMaterial)) {
-            itemStack = getItemFromHook("mmoitems", holder.setPlaceholders(stringMaterial.substring(MMOITEMS_PREFIX.length())))
+            itemStack = getItemFromHook("mmoitems", holder.setPlaceholdersAndArguments(stringMaterial.substring(MMOITEMS_PREFIX.length())))
                     .orElseGet(() -> new ItemStack(Material.STONE, temporaryAmount));
         } else if (ItemUtils.isWaterBottle(lowercaseStringMaterial)) {
             itemStack = ItemUtils.createWaterBottles(amount);
@@ -140,7 +140,7 @@ public class MenuItem {
 
             if (meta != null) {
                 if (this.options.rgb().isPresent()) {
-                    final String rgbString = holder.setPlaceholders(this.options.rgb().get());
+                    final String rgbString = holder.setPlaceholdersAndArguments(this.options.rgb().get());
                     final String[] parts = rgbString.split(",");
 
                     try {
@@ -167,7 +167,7 @@ public class MenuItem {
         short data = this.options.data();
 
         if (this.options.placeholderData().isPresent()) {
-            final String parsedData = holder.setPlaceholders(this.options.placeholderData().get());
+            final String parsedData = holder.setPlaceholdersAndArguments(this.options.placeholderData().get());
             try {
                 data = Short.parseShort(parsedData);
             } catch (final NumberFormatException exception) {
@@ -188,7 +188,7 @@ public class MenuItem {
 
         if (this.options.dynamicAmount().isPresent()) {
             try {
-                final int dynamicAmount = (int) Double.parseDouble(holder.setPlaceholders(this.options.dynamicAmount().get()));
+                final int dynamicAmount = (int) Double.parseDouble(holder.setPlaceholdersAndArguments(this.options.dynamicAmount().get()));
                 amount = Math.max(dynamicAmount, 1);
             } catch (final NumberFormatException ignored) {
             }
@@ -207,20 +207,20 @@ public class MenuItem {
 
         if (this.options.customModelData().isPresent() && VersionHelper.IS_CUSTOM_MODEL_DATA) {
             try {
-                final int modelData = Integer.parseInt(holder.setPlaceholders(this.options.customModelData().get()));
+                final int modelData = Integer.parseInt(holder.setPlaceholdersAndArguments(this.options.customModelData().get()));
                 itemMeta.setCustomModelData(modelData);
             } catch (final Exception ignored) {
             }
         }
 
         if (this.options.displayName().isPresent()) {
-            final String displayName = holder.setPlaceholders(this.options.displayName().get());
+            final String displayName = holder.setPlaceholdersAndArguments(this.options.displayName().get());
             itemMeta.setDisplayName(StringUtils.color(displayName));
         }
 
         if (!this.options.lore().isEmpty()) {
             final List<String> lore = this.options.lore().stream()
-                    .map(holder::setPlaceholders)
+                    .map(holder::setPlaceholdersAndArguments)
                     .map(StringUtils::color)
                     .map(line -> line.split("\n"))
                     .flatMap(Arrays::stream)
@@ -258,7 +258,7 @@ public class MenuItem {
         }
 
         if (itemMeta instanceof LeatherArmorMeta && this.options.rgb().isPresent()) {
-            final String rgbString = holder.setPlaceholders(this.options.rgb().get());
+            final String rgbString = holder.setPlaceholdersAndArguments(this.options.rgb().get());
             final String[] parts = rgbString.split(",");
             final LeatherArmorMeta leatherArmorMeta = (LeatherArmorMeta) itemMeta;
 
@@ -274,7 +274,7 @@ public class MenuItem {
                 );
             }
         } else if (itemMeta instanceof FireworkEffectMeta && this.options.rgb().isPresent()) {
-            final String rgbString = holder.setPlaceholders(this.options.rgb().get());
+            final String rgbString = holder.setPlaceholdersAndArguments(this.options.rgb().get());
             final String[] parts = rgbString.split(",");
             final FireworkEffectMeta fireworkEffectMeta = (FireworkEffectMeta) itemMeta;
 
@@ -312,7 +312,7 @@ public class MenuItem {
 
         if (NbtProvider.isAvailable()) {
             if (this.options.nbtString().isPresent()) {
-                final String tag = holder.setPlaceholders(this.options.nbtString().get());
+                final String tag = holder.setPlaceholdersAndArguments(this.options.nbtString().get());
                 if (tag.contains(":")) {
                     final String[] parts = tag.split(":", 2);
                     itemStack = NbtProvider.setString(itemStack, parts[0], parts[1]);
@@ -320,7 +320,7 @@ public class MenuItem {
             }
 
             if (this.options.nbtInt().isPresent()) {
-                final String tag = holder.setPlaceholders(this.options.nbtInt().get());
+                final String tag = holder.setPlaceholdersAndArguments(this.options.nbtInt().get());
                 if (tag.contains(":")) {
                     final String[] parts = tag.split(":");
                     itemStack = NbtProvider.setInt(itemStack, parts[0], Integer.parseInt(parts[1]));
@@ -328,7 +328,7 @@ public class MenuItem {
             }
 
             for (String nbtTag : this.options.nbtStrings()) {
-                final String tag = holder.setPlaceholders(nbtTag);
+                final String tag = holder.setPlaceholdersAndArguments(nbtTag);
                 if (tag.contains(":")) {
                     final String[] parts = tag.split(":", 2);
                     itemStack = NbtProvider.setString(itemStack, parts[0], parts[1]);
@@ -336,7 +336,7 @@ public class MenuItem {
             }
 
             for (String nbtTag : this.options.nbtInts()) {
-                final String tag = holder.setPlaceholders(nbtTag);
+                final String tag = holder.setPlaceholdersAndArguments(nbtTag);
                 if (tag.contains(":")) {
                     final String[] parts = tag.split(":");
                     itemStack = NbtProvider.setInt(itemStack, parts[0], Integer.parseInt(parts[1]));

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -74,20 +74,17 @@ public class MenuItem {
         final String finalMaterial = lowercaseStringMaterial;
         final ItemHook pluginHook = DeluxeMenus.getInstance().getItemHooks().values()
             .stream()
-            .filter(x -> finalMaterial.startsWith(x.getPrefix()))
+            .filter(x ->  finalMaterial.startsWith(x.getPrefix()))
             .findFirst()
             .orElse(null);
 
         if (pluginHook != null) {
-            itemStack = pluginHook.getItem(stringMaterial.substring(pluginHook.getPrefix().length()));
+            itemStack = pluginHook.getItem(holder.setPlaceholdersAndArguments(stringMaterial.substring(pluginHook.getPrefix().length())));
         }
 
         if (ItemUtils.isWaterBottle(stringMaterial)) {
             itemStack = ItemUtils.createWaterBottles(amount);
-        }
-
-        // The item is neither a water bottle nor plugin hook item
-        if (itemStack == null) {
+        } else if (itemStack == null) {
             final Material material = Material.getMaterial(stringMaterial.toUpperCase(Locale.ROOT));
             if (material == null) {
                 DeluxeMenus.debug(

--- a/src/main/java/com/extendedclip/deluxemenus/requirement/HasExpRequirement.java
+++ b/src/main/java/com/extendedclip/deluxemenus/requirement/HasExpRequirement.java
@@ -21,10 +21,10 @@ public class HasExpRequirement extends Requirement {
         int amount;
         int has = level ? holder.getViewer().getLevel() : ExpUtils.getTotalExperience(holder.getViewer());
         try {
-            amount = Integer.parseInt(holder.setPlaceholders(amt));
+            amount = Integer.parseInt(holder.setPlaceholdersAndArguments(amt));
         } catch (final Exception exception) {
             DeluxeMenus.printStacktrace(
-                "Invalid amount found for has exp requirement: " + holder.setPlaceholders(amt),
+                "Invalid amount found for has exp requirement: " + holder.setPlaceholdersAndArguments(amt),
                 exception
             );
             return false;

--- a/src/main/java/com/extendedclip/deluxemenus/requirement/HasItemRequirement.java
+++ b/src/main/java/com/extendedclip/deluxemenus/requirement/HasItemRequirement.java
@@ -23,7 +23,7 @@ public class HasItemRequirement extends Requirement {
 
   @Override
   public boolean evaluate(MenuHolder holder) {
-    String materialName = holder.setPlaceholders(wrapper.getMaterial()).toUpperCase();
+    String materialName = holder.setPlaceholdersAndArguments(wrapper.getMaterial()).toUpperCase();
     Material material = DeluxeMenus.MATERIALS.get(materialName);
     if (material == null) {
       return invert;
@@ -87,8 +87,8 @@ public class HasItemRequirement extends Requirement {
       if (wrapper.getName() != null) {
         if (!metaToCheck.hasDisplayName()) return false;
 
-        String name = StringUtils.color(holder.setPlaceholders(wrapper.getName()));
-        String nameToCheck = StringUtils.color(holder.setPlaceholders(metaToCheck.getDisplayName()));
+        String name = StringUtils.color(holder.setPlaceholdersAndArguments(wrapper.getName()));
+        String nameToCheck = StringUtils.color(holder.setPlaceholdersAndArguments(metaToCheck.getDisplayName()));
 
         if (wrapper.checkNameContains() && wrapper.checkNameIgnoreCase()) {
           if (!org.apache.commons.lang3.StringUtils.containsIgnoreCase(nameToCheck, name)) return false;
@@ -108,8 +108,8 @@ public class HasItemRequirement extends Requirement {
         List<String> loreX = metaToCheck.getLore();
         if (loreX == null) return false;
 
-        String lore = wrapper.getLoreList().stream().map(holder::setPlaceholders).map(StringUtils::color).collect(Collectors.joining("&&"));
-        String loreToCheck = loreX.stream().map(holder::setPlaceholders).map(StringUtils::color).collect(Collectors.joining("&&"));
+        String lore = wrapper.getLoreList().stream().map(holder::setPlaceholdersAndArguments).map(StringUtils::color).collect(Collectors.joining("&&"));
+        String loreToCheck = loreX.stream().map(holder::setPlaceholdersAndArguments).map(StringUtils::color).collect(Collectors.joining("&&"));
 
         if (wrapper.checkLoreContains() && wrapper.checkLoreIgnoreCase()) {
           if (!org.apache.commons.lang3.StringUtils.containsIgnoreCase(loreToCheck, lore)) return false;
@@ -129,8 +129,8 @@ public class HasItemRequirement extends Requirement {
         List<String> loreX = metaToCheck.getLore();
         if (loreX == null) return false;
 
-        String lore = StringUtils.color(holder.setPlaceholders(wrapper.getLore()));
-        String loreToCheck = loreX.stream().map(holder::setPlaceholders).map(StringUtils::color).collect(Collectors.joining("&&"));
+        String lore = StringUtils.color(holder.setPlaceholdersAndArguments(wrapper.getLore()));
+        String loreToCheck = loreX.stream().map(holder::setPlaceholdersAndArguments).map(StringUtils::color).collect(Collectors.joining("&&"));
 
         if (wrapper.checkLoreContains() && wrapper.checkLoreIgnoreCase()) {
           return org.apache.commons.lang3.StringUtils.containsIgnoreCase(loreToCheck, lore);

--- a/src/main/java/com/extendedclip/deluxemenus/requirement/HasMetaRequirement.java
+++ b/src/main/java/com/extendedclip/deluxemenus/requirement/HasMetaRequirement.java
@@ -24,15 +24,15 @@ public class HasMetaRequirement extends Requirement {
     if (player == null) {
       return false;
     }
-    String parsedKey = holder.setPlaceholders(key);
+    String parsedKey = holder.setPlaceholdersAndArguments(key);
     String metaVal = DeluxeMenus.getInstance().getPersistentMetaHandler()
         .getMeta(player, parsedKey, type, null);
     if (metaVal == null) {
       return invert;
     }
 
-    String expected = holder.setPlaceholders(value);
-    metaVal = holder.setPlaceholders(metaVal);
+    String expected = holder.setPlaceholdersAndArguments(value);
+    metaVal = holder.setPlaceholdersAndArguments(metaVal);
 
     switch (type) {
       case "STRING":

--- a/src/main/java/com/extendedclip/deluxemenus/requirement/HasMoneyRequirement.java
+++ b/src/main/java/com/extendedclip/deluxemenus/requirement/HasMoneyRequirement.java
@@ -23,11 +23,11 @@ public class HasMoneyRequirement extends Requirement {
 
     if (placeholder != null) {
       try {
-        String expected = holder.setPlaceholders(placeholder);
+        String expected = holder.setPlaceholdersAndArguments(placeholder);
         amount = Double.parseDouble(expected);
       } catch (final NumberFormatException exception) {
         DeluxeMenus.printStacktrace(
-            "Invalid amount found for has money requirement: " + holder.setPlaceholders(placeholder),
+            "Invalid amount found for has money requirement: " + holder.setPlaceholdersAndArguments(placeholder),
             exception
         );
       }

--- a/src/main/java/com/extendedclip/deluxemenus/requirement/HasPermissionRequirement.java
+++ b/src/main/java/com/extendedclip/deluxemenus/requirement/HasPermissionRequirement.java
@@ -14,7 +14,7 @@ public class HasPermissionRequirement extends Requirement {
 
   @Override
   public boolean evaluate(MenuHolder holder) {
-    String check = holder.setPlaceholders(perm);
+    String check = holder.setPlaceholdersAndArguments(perm);
     if (invert) {
       return !holder.getViewer().hasPermission(check);
     } else {

--- a/src/main/java/com/extendedclip/deluxemenus/requirement/InputResultRequirement.java
+++ b/src/main/java/com/extendedclip/deluxemenus/requirement/InputResultRequirement.java
@@ -18,8 +18,8 @@ public class InputResultRequirement extends Requirement {
   @Override
   public boolean evaluate(MenuHolder holder) {
 
-    String parsedInput = holder.setPlaceholders(this.input);
-    String parsedResult = holder.setPlaceholders(this.result);
+    String parsedInput = holder.setPlaceholdersAndArguments(this.input);
+    String parsedResult = holder.setPlaceholdersAndArguments(this.result);
 
     switch (type) {
       case STRING_CONTAINS:

--- a/src/main/java/com/extendedclip/deluxemenus/requirement/IsObjectRequirement.java
+++ b/src/main/java/com/extendedclip/deluxemenus/requirement/IsObjectRequirement.java
@@ -22,7 +22,7 @@ public class IsObjectRequirement extends Requirement {
 
     @Override
     public boolean evaluate(MenuHolder holder) {
-        String toCheck = holder.setPlaceholders(input);
+        String toCheck = holder.setPlaceholdersAndArguments(input);
 
         switch (object) {
             case "int":

--- a/src/main/java/com/extendedclip/deluxemenus/requirement/JavascriptRequirement.java
+++ b/src/main/java/com/extendedclip/deluxemenus/requirement/JavascriptRequirement.java
@@ -38,7 +38,7 @@ public class JavascriptRequirement extends Requirement {
   @Override
   public boolean evaluate(MenuHolder holder) {
 
-    String exp = holder.setPlaceholders(expression);
+    String exp = holder.setPlaceholdersAndArguments(expression);
     try {
 
       engine.put("BukkitPlayer", holder.getViewer());

--- a/src/main/java/com/extendedclip/deluxemenus/requirement/RegexMatchesRequirement.java
+++ b/src/main/java/com/extendedclip/deluxemenus/requirement/RegexMatchesRequirement.java
@@ -17,11 +17,11 @@ public class RegexMatchesRequirement extends Requirement {
 
   @Override
   public boolean evaluate(MenuHolder holder) {
-    String toCheck = holder.setPlaceholders(input);
+    String toCheck = holder.setPlaceholdersAndArguments(input);
     if (invert) {
-      return !pattern.matcher(holder.setPlaceholders(toCheck)).find();
+      return !pattern.matcher(holder.setPlaceholdersAndArguments(toCheck)).find();
     } else {
-      return pattern.matcher(holder.setPlaceholders(toCheck)).find();
+      return pattern.matcher(holder.setPlaceholdersAndArguments(toCheck)).find();
     }
   }
 }

--- a/src/main/java/com/extendedclip/deluxemenus/requirement/StringLengthRequirement.java
+++ b/src/main/java/com/extendedclip/deluxemenus/requirement/StringLengthRequirement.java
@@ -16,7 +16,7 @@ public class StringLengthRequirement extends Requirement {
 
     @Override
     public boolean evaluate(MenuHolder holder) {
-        String toCheck = holder.setPlaceholders(input);
+        String toCheck = holder.setPlaceholdersAndArguments(input);
         if (max == null) {
             return toCheck.length() >= min;
         } else {

--- a/src/main/java/com/extendedclip/deluxemenus/utils/StringUtils.java
+++ b/src/main/java/com/extendedclip/deluxemenus/utils/StringUtils.java
@@ -1,34 +1,66 @@
 package com.extendedclip.deluxemenus.utils;
 
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import me.clip.placeholderapi.PlaceholderAPI;
 import net.md_5.bungee.api.ChatColor;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class StringUtils {
 
-  private final static Pattern HEX_PATTERN = Pattern
-      .compile("&(#[a-f0-9]{6})", Pattern.CASE_INSENSITIVE);
+    private final static Pattern HEX_PATTERN = Pattern
+            .compile("&(#[a-f0-9]{6})", Pattern.CASE_INSENSITIVE);
 
-  /**
-   * Translates the ampersand color codes like '&7' to their section symbol counterparts like '§7'.
-   * <br>
-   * It also translates hex colors like '&#aaFF00' to their section symbol counterparts like '§x§a§a§F§F§0§0'.
-   *
-   * @param input The string in which to translate the color codes.
-   * @return The string with the translated colors.
-   */
-  @NotNull
-  public static String color(@NotNull String input) {
-    //Hex Support for 1.16.1+
-    Matcher m = HEX_PATTERN.matcher(input);
-    if (VersionHelper.IS_HEX_VERSION) {
-      while (m.find()) {
-        input = input.replace(m.group(), ChatColor.of(m.group(1)).toString());
-      }
+    /**
+     * Translates the ampersand color codes like '&7' to their section symbol counterparts like '§7'.
+     * <br>
+     * It also translates hex colors like '&#aaFF00' to their section symbol counterparts like '§x§a§a§F§F§0§0'.
+     *
+     * @param input The string in which to translate the color codes.
+     * @return The string with the translated colors.
+     */
+    @NotNull
+    public static String color(@NotNull String input) {
+        // Hex Support for 1.16.1+
+        Matcher m = HEX_PATTERN.matcher(input);
+        if (VersionHelper.IS_HEX_VERSION) {
+            while (m.find()) {
+                input = input.replace(m.group(), ChatColor.of(m.group(1)).toString());
+            }
+        }
+
+        return ChatColor.translateAlternateColorCodes('&', input);
     }
 
-    return ChatColor.translateAlternateColorCodes('&', input);
-  }
+    @NotNull
+    public static String replacePlaceholdersAndArguments(@NotNull String input, final @Nullable Map<String, String> arguments, final @Nullable Player player) {
+        if (player == null) {
+            return replaceArguments(input, arguments, null);
+        }
 
+        return replaceArguments(replacePlaceholders(input, player), arguments, player);
+    }
+
+    @NotNull
+    public static String replacePlaceholders(final @NotNull String input, final @NotNull Player player) {
+        return PlaceholderAPI.setPlaceholders(player, input);
+    }
+
+    @NotNull
+    public static String replaceArguments(@NotNull String input, final @Nullable Map<String, String> arguments, final @Nullable Player player) {
+        if (arguments == null || arguments.isEmpty()) {
+            return input;
+        }
+
+        for (final Map.Entry<String, String> entry : arguments.entrySet()) {
+            final String value = player != null ? replacePlaceholders(entry.getValue(), player) : entry.getValue();
+            input = input.replace("{" + entry.getKey() + "}", value);
+        }
+
+        return input;
+    }
 }

--- a/src/main/java/com/extendedclip/deluxemenus/utils/StringUtils.java
+++ b/src/main/java/com/extendedclip/deluxemenus/utils/StringUtils.java
@@ -37,12 +37,13 @@ public class StringUtils {
     }
 
     @NotNull
-    public static String replacePlaceholdersAndArguments(@NotNull String input, final @Nullable Map<String, String> arguments, final @Nullable Player player) {
+    public static String replacePlaceholdersAndArguments(@NotNull String input, final @Nullable Map<String, String> arguments,
+                                                         final @Nullable Player player, boolean parsePlaceholdersInsideArguments) {
         if (player == null) {
-            return replaceArguments(input, arguments, null);
+            return replaceArguments(input, arguments, null, parsePlaceholdersInsideArguments);
         }
 
-        return replaceArguments(replacePlaceholders(input, player), arguments, player);
+        return replaceArguments(replacePlaceholders(input, player), arguments, player, parsePlaceholdersInsideArguments);
     }
 
     @NotNull
@@ -51,13 +52,16 @@ public class StringUtils {
     }
 
     @NotNull
-    public static String replaceArguments(@NotNull String input, final @Nullable Map<String, String> arguments, final @Nullable Player player) {
+    public static String replaceArguments(@NotNull String input, final @Nullable Map<String, String> arguments,
+                                          final @Nullable Player player, boolean parsePlaceholdersInsideArguments) {
         if (arguments == null || arguments.isEmpty()) {
             return input;
         }
 
         for (final Map.Entry<String, String> entry : arguments.entrySet()) {
-            final String value = player != null ? replacePlaceholders(entry.getValue(), player) : entry.getValue();
+            final String value = player != null && parsePlaceholdersInsideArguments
+                    ? replacePlaceholders(entry.getValue(), player)
+                    : entry.getValue();
             input = input.replace("{" + entry.getKey() + "}", value);
         }
 


### PR DESCRIPTION
- Added per menu option `arguments_support_placeholders` that takes in a boolean value and defaults to `false`. When option is `false`, placeholders are not parsed inside user arguments.
- Changed how placeholders and arguments are parsed: arguments first (with placeholders inside value parsed if option mentioned above is true) and then placeholders

- Fixed placeholders not being parsed for itemhooks anymore.