### PR TITLE
Add argument validation and `is object` + `string length` requirements

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -1352,6 +1352,33 @@ public class DeluxeMenusConfig {
             );
           }
           break;
+        case STRING_LENGTH:
+          if (c.contains(rPath + ".input") && (c.contains(rPath + ".min") || c.contains(rPath + ".max"))) {
+            int min = c.getInt(rPath + ".min", 0);
+            Integer max = null;
+            if (c.contains(rPath + ".max")) {
+              max = c.getInt(rPath + ".max");
+            }
+            req = new StringLengthRequirement(c.getString(rPath + ".input"), min, max);
+          } else {
+            DeluxeMenus.debug(
+                DebugLevel.HIGHEST,
+                Level.WARNING,
+                "String length requirement at path: " + rPath + " does not contain an input: or one of (min: or max:)"
+            );
+          }
+          break;
+        case IS_OBJECT:
+          if (c.contains(rPath + ".input") && c.contains(rPath + ".object")) {
+            req = new IsObjectRequirement(c.getString(rPath + ".input"), c.getString(rPath + ".object"));
+          } else {
+            DeluxeMenus.debug(
+                DebugLevel.HIGHEST,
+                Level.WARNING,
+                "String length requirement at path: " + rPath + " does not contain an input: or one of (min: or max:)"
+            );
+          }
+          break;
         default:
           break;
       }

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -1375,7 +1375,7 @@ public class DeluxeMenusConfig {
             DeluxeMenus.debug(
                 DebugLevel.HIGHEST,
                 Level.WARNING,
-                "String length requirement at path: " + rPath + " does not contain an input: or one of (min: or max:)"
+                "String length requirement at path: " + rPath + " does not contain an input: or object:"
             );
           }
           break;

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
@@ -89,17 +89,20 @@ public class MenuHolder implements InventoryHolder {
   }
 
   public String setPlaceholders(String string) {
-    if (this.typedArgs == null || this.typedArgs.isEmpty()) {
-      if (placeholderPlayer != null) return PlaceholderAPI.setPlaceholders((OfflinePlayer) placeholderPlayer, string);
-      else return this.getViewer() == null ? string
-          : PlaceholderAPI.setPlaceholders((OfflinePlayer) this.getViewer(), string);
+    // Set argument placeholders first
+    if (this.typedArgs != null && !this.typedArgs.isEmpty()) {
+      for (Entry<String, String> entry : typedArgs.entrySet()) {
+        string = string.replace("{" + entry.getKey() + "}", entry.getValue());
+      }
     }
-    for (Entry<String, String> entry : typedArgs.entrySet()) {
-      string = string.replace("{" + entry.getKey() + "}", entry.getValue());
+
+    // Then set actual PAPI placeholders
+    if (placeholderPlayer != null) {
+      return PlaceholderAPI.setPlaceholders((OfflinePlayer) placeholderPlayer, string);
+    } else {
+      return this.getViewer() == null ? string
+              : PlaceholderAPI.setPlaceholders((OfflinePlayer) this.getViewer(), string);
     }
-    if (placeholderPlayer != null) return PlaceholderAPI.setPlaceholders((OfflinePlayer) placeholderPlayer, string);
-    else return this.getViewer() == null ? string
-        : PlaceholderAPI.setPlaceholders((OfflinePlayer) this.getViewer(), string);
   }
 
   public String setArguments(String string) {

--- a/src/main/java/com/extendedclip/deluxemenus/requirement/IsObjectRequirement.java
+++ b/src/main/java/com/extendedclip/deluxemenus/requirement/IsObjectRequirement.java
@@ -1,0 +1,51 @@
+package com.extendedclip.deluxemenus.requirement;
+
+import com.extendedclip.deluxemenus.DeluxeMenus;
+import com.extendedclip.deluxemenus.menu.MenuHolder;
+import com.extendedclip.deluxemenus.utils.DebugLevel;
+import com.google.common.primitives.Doubles;
+import com.google.common.primitives.Ints;
+import org.bukkit.Bukkit;
+
+import java.util.UUID;
+import java.util.logging.Level;
+
+public class IsObjectRequirement extends Requirement {
+
+    private final String input;
+    private final String object;
+
+    public IsObjectRequirement(String input, String object) {
+        this.input = input;
+        this.object = object;
+    }
+
+    @Override
+    public boolean evaluate(MenuHolder holder) {
+        String toCheck = holder.setPlaceholders(input);
+
+        switch (object) {
+            case "int":
+                return Ints.tryParse(toCheck) != null;
+            case "double":
+                return Doubles.tryParse(toCheck) != null;
+            case "player":
+                try {
+                    UUID id = UUID.fromString(toCheck);
+                    return Bukkit.getPlayer(id) != null;
+                } catch (IllegalArgumentException e) {
+                    return Bukkit.getPlayerExact(toCheck) != null;
+                }
+            case "uuid":
+                try {
+                    UUID.fromString(toCheck);
+                    return true;
+                } catch (IllegalArgumentException e) {
+                    return false;
+                }
+            default:
+                DeluxeMenus.debug(DebugLevel.HIGHEST, Level.INFO, "Invalid object: " + object + " in \"is object\" check.");
+                return false;
+        }
+    }
+}

--- a/src/main/java/com/extendedclip/deluxemenus/requirement/RequirementType.java
+++ b/src/main/java/com/extendedclip/deluxemenus/requirement/RequirementType.java
@@ -75,7 +75,13 @@ public enum RequirementType {
       Arrays.asList("input", "regex")),
   REGEX_DOES_NOT_MATCH(Arrays.asList("!regex matches", "!regex"),
       "Checks if a placeholder parsed string does not match a regex pattern",
-      Arrays.asList("input", "regex"));
+      Arrays.asList("input", "regex")),
+  STRING_LENGTH(Arrays.asList("string length"),
+  "Checks if the given string's length is between the provided minimum and (optionally) maximum.",
+          Arrays.asList("input", "min", "max")),
+  IS_OBJECT(Arrays.asList("is object"),
+          "Checks if the given string can be parsed as a given Java object.",
+          Arrays.asList("input", "object"));
 
   private final List<String> identifier;
   private final String description;

--- a/src/main/java/com/extendedclip/deluxemenus/requirement/StringLengthRequirement.java
+++ b/src/main/java/com/extendedclip/deluxemenus/requirement/StringLengthRequirement.java
@@ -1,0 +1,26 @@
+package com.extendedclip.deluxemenus.requirement;
+
+import com.extendedclip.deluxemenus.menu.MenuHolder;
+
+public class StringLengthRequirement extends Requirement {
+
+    private final String input;
+    private final int min;
+    private final Integer max;
+
+    public StringLengthRequirement(String input, int min, Integer max) {
+        this.input = input;
+        this.min = min;
+        this.max = max;
+    }
+
+    @Override
+    public boolean evaluate(MenuHolder holder) {
+        String toCheck = holder.setPlaceholders(input);
+        if (max == null) {
+            return toCheck.length() >= min;
+        } else {
+            return toCheck.length() >= min && toCheck.length() <= max;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the ability to list argument validation directly in the arguments list, while also maintaining backwards compatibility.

Example: [https://paste.helpch.at/medacemeve.yaml](https://paste.helpch.at/medacemeve.yaml)

## Requirements

This PR also adds two new requirements to facilitate most argument validation: `is object` & `string length`.

`string length` is very simple, it takes an input, and either a `max`, a `min`, or both. Example:
```yaml
      length:
        type: "string length"
        input: "{player}"
        min: 2
        max: 32
        deny_commands:
          - "[message] Player must be between 2 and 32 characters long."
```

`is object` is a bit more complex, but also more useful. It attempts to parse the given input as a certain type of Java object. The current options are `int`, `double`, `uuid`, and `player`. The first three are self-explanatory. `player` works for both UUIDs and usernames, and uses `Bukkit.getPlayer(UUID)` and `Bukkit.getPlayerExact(USERNAME)` to ensure only real online players are counted. Example:
```yaml
      player:
        type: "is object"
        input: "{player}"
        object: "player"
        deny_commands:
          - "[message] Must be a player's username or UUID."
```

## Further Discussion

A topic open for discussion is the inclusion of an `offlineplayer` type for `is object`. On Spigot, this can be abused to send multiple HTTP requests to Mojang on the main thread, thereby lagging servers heavily. On Paper, there is a method that only accesses local storage and is therefore safe, but DeluxeMenus currently does not have the requisite infrastructure, in my opinion, to do something specifically for Paper only.