### PR TITLE
Add MMOItems Hook

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ repositories {
     maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
     maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
     maven("https://repo.glaremasters.me/repository/public/")
+    maven("https://nexus.phoenixdevt.fr/repository/maven-public/")
     maven("https://jitpack.io")
 }
 
@@ -29,6 +30,7 @@ dependencies {
     compileOnly(libs.headdb)
     compileOnly(libs.itemsadder)
     compileOnly(libs.oraxen)
+    compileOnly(libs.mmoitems)
 
     compileOnly(libs.papi)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ authlib = "1.5.25"
 headdb = "1.3.1"
 itemsadder = "3.2.5"
 oraxen = "1.159.0"
+mmoitems = "6.9.4-SNAPSHOT"
 papi = "2.11.2"
 
 # Implementation
@@ -21,6 +22,7 @@ authlib = { module = "com.mojang:authlib", version.ref = "authlib" }
 headdb = { module = "com.arcaniax:HeadDatabase-API", version.ref = "headdb" }
 itemsadder = { module = "com.github.LoneDev6:api-itemsadder", version.ref = "itemsadder" }
 oraxen = { module = "com.github.oraxen:oraxen", version.ref = "oraxen" }
+mmoitems = { module = "net.Indyuce:MMOItems-API", version.ref = "mmoitems" }
 papi = { module = "me.clip:placeholderapi", version.ref = "papi" }
 
 # Implementation

--- a/src/main/java/com/extendedclip/deluxemenus/DeluxeMenus.java
+++ b/src/main/java/com/extendedclip/deluxemenus/DeluxeMenus.java
@@ -5,14 +5,7 @@ import com.extendedclip.deluxemenus.commands.DeluxeMenusCommands;
 import com.extendedclip.deluxemenus.config.DeluxeMenusConfig;
 import com.extendedclip.deluxemenus.dupe.DupeFixer;
 import com.extendedclip.deluxemenus.dupe.MenuItemMarker;
-import com.extendedclip.deluxemenus.hooks.BaseHeadHook;
-import com.extendedclip.deluxemenus.hooks.HeadDatabaseHook;
-import com.extendedclip.deluxemenus.hooks.ItemHook;
-import com.extendedclip.deluxemenus.hooks.ItemsAdderHook;
-import com.extendedclip.deluxemenus.hooks.NamedHeadHook;
-import com.extendedclip.deluxemenus.hooks.OraxenHook;
-import com.extendedclip.deluxemenus.hooks.TextureHeadHook;
-import com.extendedclip.deluxemenus.hooks.VaultHook;
+import com.extendedclip.deluxemenus.hooks.*;
 import com.extendedclip.deluxemenus.listener.PlayerListener;
 import com.extendedclip.deluxemenus.menu.HeadType;
 import com.extendedclip.deluxemenus.menu.Menu;
@@ -214,6 +207,10 @@ public class DeluxeMenus extends JavaPlugin {
 
     if (Bukkit.getPluginManager().isPluginEnabled("Oraxen")) {
       itemHooks.put("oraxen", new OraxenHook());
+    }
+
+    if (Bukkit.getPluginManager().isPluginEnabled("MMOItems")) {
+      itemHooks.put("mmoitems", new MMOItemsHook());
     }
   }
 

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -44,12 +44,7 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
-import static com.extendedclip.deluxemenus.utils.Constants.HEAD_PREFIXES;
-import static com.extendedclip.deluxemenus.utils.Constants.ITEMSADDER_PREFIX;
-import static com.extendedclip.deluxemenus.utils.Constants.ORAXEN_PREFIX;
-import static com.extendedclip.deluxemenus.utils.Constants.PLACEHOLDER_PREFIX;
-import static com.extendedclip.deluxemenus.utils.Constants.PLAYER_ITEMS;
-import static com.extendedclip.deluxemenus.utils.Constants.WATER_BOTTLE;
+import static com.extendedclip.deluxemenus.utils.Constants.*;
 
 public class DeluxeMenusConfig {
 
@@ -64,6 +59,7 @@ public class DeluxeMenusConfig {
     VALID_MATERIAL_PREFIXES.add(PLACEHOLDER_PREFIX);
     VALID_MATERIAL_PREFIXES.add(ITEMSADDER_PREFIX);
     VALID_MATERIAL_PREFIXES.add(ORAXEN_PREFIX);
+    VALID_MATERIAL_PREFIXES.add(MMOITEMS_PREFIX);
   }
 
   public static final Pattern DELAY_MATCHER = Pattern.compile("<delay=([^<>]+)>", Pattern.CASE_INSENSITIVE);

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/MMOItemsHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/MMOItemsHook.java
@@ -1,0 +1,71 @@
+package com.extendedclip.deluxemenus.hooks;
+
+import com.extendedclip.deluxemenus.DeluxeMenus;
+import com.extendedclip.deluxemenus.cache.SimpleCache;
+import com.extendedclip.deluxemenus.utils.DebugLevel;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.logging.Level;
+
+import net.Indyuce.mmoitems.MMOItems;
+import net.Indyuce.mmoitems.api.Type;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+public class MMOItemsHook implements ItemHook, SimpleCache {
+
+    private final Map<String, ItemStack> cache = new ConcurrentHashMap<>();
+
+    @Override
+    public ItemStack getItem(@NotNull final String... arguments) {
+        if (arguments.length == 0) {
+            return new ItemStack(Material.STONE, 1);
+        }
+
+        final ItemStack cached = cache.get(arguments[0]);
+        if (cached != null) {
+            return cached.clone();
+        }
+
+        String[] splitArgs = arguments[0].split(":");
+        if (splitArgs.length != 2) {
+            return new ItemStack(Material.STONE, 1);
+        }
+
+        final Type itemType = MMOItems.plugin.getTypes().get(splitArgs[0]);
+        if (itemType == null) {
+            return new ItemStack(Material.STONE, 1);
+        }
+
+        ItemStack mmoItem = null;
+        try {
+            mmoItem = Bukkit.getScheduler().callSyncMethod(DeluxeMenus.getInstance(), () -> {
+                ItemStack item = MMOItems.plugin.getItem(itemType, splitArgs[1]);
+
+                if (item == null) {
+                    return new ItemStack(Material.STONE, 1);
+                }
+
+                cache.put(arguments[0], item);
+
+                return item;
+            }).get();
+        } catch (InterruptedException | ExecutionException e) {
+            DeluxeMenus.debug(DebugLevel.HIGHEST, Level.SEVERE, "Error getting MMOItem synchronously.");
+        }
+
+        if (mmoItem == null) {
+            return new ItemStack(Material.STONE, 1);
+        } else {
+            return mmoItem;
+        }
+    }
+
+    @Override
+    public void clearCache() {
+        cache.clear();
+    }
+}

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -158,6 +158,9 @@ public class MenuItem implements Cloneable {
         } else if (isOraxenItem(lowercaseStringMaterial)) {
             itemStack = getItemFromHook("oraxen", holder.setPlaceholders(stringMaterial.substring(ORAXEN_PREFIX.length())))
                     .orElseGet(() -> new ItemStack(Material.STONE, temporaryAmount));
+        } else if (isMMOItemsItem(lowercaseStringMaterial)) {
+            itemStack = getItemFromHook("mmoitems", holder.setPlaceholders(stringMaterial.substring(MMOITEMS_PREFIX.length())))
+                    .orElseGet(() -> new ItemStack(Material.STONE, temporaryAmount));
         } else if (isWaterBottle(lowercaseStringMaterial)) {
             itemStack = createWaterBottle(amount);
         } else if (itemStack == null) {
@@ -469,13 +472,24 @@ public class MenuItem implements Cloneable {
 
     /**
      * Checks if the string is an Oraxen item. The check is case-sensitive.
-     * ItemsAdder items are: "oraxen-{namespace:name}"
+     * Oraxen items are: "oraxen-{namespace:name}"
      *
      * @param material The string to check
      * @return true if the string is an Oraxen item, false otherwise
      */
     private boolean isOraxenItem(@NotNull final String material) {
         return material.startsWith(ORAXEN_PREFIX);
+    }
+
+    /**
+     * Checks if the string is an MMOItems item. The check is case-sensitive.
+     * MMOItems items are: "mmoitems-{namespace:name}"
+     *
+     * @param material The string to check
+     * @return true if the string is an MMOItem item, false otherwise
+     */
+    private boolean isMMOItemsItem(@NotNull final String material) {
+        return material.startsWith(MMOITEMS_PREFIX);
     }
 
     /**

--- a/src/main/java/com/extendedclip/deluxemenus/utils/Constants.java
+++ b/src/main/java/com/extendedclip/deluxemenus/utils/Constants.java
@@ -35,6 +35,7 @@ public final class Constants {
 
     public static final String ITEMSADDER_PREFIX = "itemsadder-";
     public static final String ORAXEN_PREFIX = "oraxen-";
+    public static final String MMOITEMS_PREFIX = "mmoitems-";
 
 
 }


### PR DESCRIPTION
This PR adds an MMOItems hook.

There is currently an issue in MMOItems that requires item creation to be done sync. This has been remedied with `Bukkit.getScheduler().callSyncMethod()`. The MMOItems developers are aware of the issue and have already deprecated the associated code [in this commit](https://gitlab.com/phoenix-dvpmt/mmoitems/-/commit/5f1e32d581590a6af8f272a526ac4023337b3868). Once that goes through, an update should be made to simplify this hook.

Closes #11 