### PR TITLE
Added placeholder prefix back to valid material prefixes

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -59,6 +59,7 @@ public class DeluxeMenusConfig {
     VALID_MATERIALS.addAll(PLAYER_ITEMS);
     VALID_MATERIALS.add(WATER_BOTTLE);
 
+    VALID_MATERIAL_PREFIXES.add(PLACEHOLDER_PREFIX);
     VALID_MATERIAL_PREFIXES.addAll(
         DeluxeMenus.getInstance().getItemHooks().values()
             .stream()


### PR DESCRIPTION
Placeholder prefix was removed from valid material prefixes, added it back.


![Fe56oGh](https://github.com/HelpChat/DeluxeMenus/assets/15619845/ff290d68-fbd0-4518-9237-e200f798b1be)
