### PR TITLE
feat: `{item}` placeholder for MenuItem

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
@@ -105,6 +105,10 @@ public class MenuHolder implements InventoryHolder {
     }
   }
 
+  public String setPlaceholdersWithOptions(String value, MenuItemOptions options) {
+    return this.setPlaceholders(value.replace("{slot}", String.valueOf(options.slot())));
+  }
+
   public String setArguments(String string) {
     if (this.typedArgs == null || this.typedArgs.isEmpty()) {
       return string;
@@ -242,14 +246,14 @@ public class MenuHolder implements InventoryHolder {
 
             if (item.options().dynamicAmount().isPresent()) {
               try {
-               amt = Integer.parseInt(setPlaceholders(item.options().dynamicAmount().get()));
+               amt = Integer.parseInt(setPlaceholdersWithOptions(item.options().dynamicAmount().get(), item.options()));
                 if (amt <= 0) {
                   amt = 1;
                 }
               } catch (Exception exception) {
                 DeluxeMenus.printStacktrace(
                     "Something went wrong while updating item in slot " + item.options().slot() +
-                        ". Invalid dynamic amount: " + setPlaceholders(item.options().dynamicAmount().get()),
+                        ". Invalid dynamic amount: " + setPlaceholdersWithOptions(item.options().dynamicAmount().get(), item.options()),
                     exception
                 );
               }
@@ -258,7 +262,7 @@ public class MenuHolder implements InventoryHolder {
             ItemMeta meta = i.getItemMeta();
 
             if (item.options().displayNameHasPlaceholders() && item.options().displayName().isPresent()) {
-              meta.setDisplayName(StringUtils.color(setPlaceholders(item.options().displayName().get())));
+              meta.setDisplayName(StringUtils.color(setPlaceholdersWithOptions(item.options().displayName().get(), item.options())));
             }
 
             if (item.options().loreHasPlaceholders()) {
@@ -267,7 +271,7 @@ public class MenuHolder implements InventoryHolder {
 
               for (String line : item.options().lore()) {
                 updated.add(StringUtils
-                    .color(setPlaceholders(line)));
+                    .color(setPlaceholdersWithOptions(line, item.options())));
               }
               meta.setLore(updated);
             }

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -54,7 +54,7 @@ public class MenuItem {
         String lowercaseStringMaterial = stringMaterial.toLowerCase(Locale.ROOT);
 
         if (ItemUtils.isPlaceholderMaterial(lowercaseStringMaterial)) {
-            stringMaterial = holder.setPlaceholders(stringMaterial.substring(PLACEHOLDER_PREFIX.length()));
+            stringMaterial = holder.setPlaceholdersWithOptions(stringMaterial.substring(PLACEHOLDER_PREFIX.length()), this.options);
             lowercaseStringMaterial = stringMaterial.toLowerCase(Locale.ENGLISH);
         }
 
@@ -139,7 +139,7 @@ public class MenuItem {
 
             if (meta != null) {
                 if (this.options.rgb().isPresent()) {
-                    final String rgbString = holder.setPlaceholders(this.options.rgb().get());
+                    final String rgbString = holder.setPlaceholdersWithOptions(this.options.rgb().get(), this.options);
                     final String[] parts = rgbString.split(",");
 
                     try {
@@ -166,7 +166,7 @@ public class MenuItem {
         short data = this.options.data();
 
         if (this.options.placeholderData().isPresent()) {
-            final String parsedData = holder.setPlaceholders(this.options.placeholderData().get());
+            final String parsedData = holder.setPlaceholdersWithOptions(this.options.placeholderData().get(), this.options);
             try {
                 data = Short.parseShort(parsedData);
             } catch (final NumberFormatException exception) {
@@ -187,7 +187,7 @@ public class MenuItem {
 
         if (this.options.dynamicAmount().isPresent()) {
             try {
-                final int dynamicAmount = (int) Double.parseDouble(holder.setPlaceholders(this.options.dynamicAmount().get()));
+                final int dynamicAmount = (int) Double.parseDouble(holder.setPlaceholdersWithOptions(this.options.dynamicAmount().get(), this.options));
                 amount = Math.max(dynamicAmount, 1);
             } catch (final NumberFormatException ignored) {
             }
@@ -206,14 +206,14 @@ public class MenuItem {
 
         if (this.options.customModelData().isPresent() && VersionHelper.IS_CUSTOM_MODEL_DATA) {
             try {
-                final int modelData = Integer.parseInt(holder.setPlaceholders(this.options.customModelData().get()));
+                final int modelData = Integer.parseInt(holder.setPlaceholdersWithOptions(this.options.customModelData().get(), this.options));
                 itemMeta.setCustomModelData(modelData);
             } catch (final Exception ignored) {
             }
         }
 
         if (this.options.displayName().isPresent()) {
-            final String displayName = holder.setPlaceholders(this.options.displayName().get());
+            final String displayName = holder.setPlaceholdersWithOptions(this.options.displayName().get(), this.options);
             itemMeta.setDisplayName(StringUtils.color(displayName));
         }
 
@@ -257,7 +257,7 @@ public class MenuItem {
         }
 
         if (itemMeta instanceof LeatherArmorMeta && this.options.rgb().isPresent()) {
-            final String rgbString = holder.setPlaceholders(this.options.rgb().get());
+            final String rgbString = holder.setPlaceholdersWithOptions(this.options.rgb().get(), this.options);
             final String[] parts = rgbString.split(",");
             final LeatherArmorMeta leatherArmorMeta = (LeatherArmorMeta) itemMeta;
 
@@ -273,7 +273,7 @@ public class MenuItem {
                 );
             }
         } else if (itemMeta instanceof FireworkEffectMeta && this.options.rgb().isPresent()) {
-            final String rgbString = holder.setPlaceholders(this.options.rgb().get());
+            final String rgbString = holder.setPlaceholdersWithOptions(this.options.rgb().get(), this.options);
             final String[] parts = rgbString.split(",");
             final FireworkEffectMeta fireworkEffectMeta = (FireworkEffectMeta) itemMeta;
 
@@ -311,7 +311,7 @@ public class MenuItem {
 
         if (NbtProvider.isAvailable()) {
             if (this.options.nbtString().isPresent()) {
-                final String tag = holder.setPlaceholders(this.options.nbtString().get());
+                final String tag = holder.setPlaceholdersWithOptions(this.options.nbtString().get(), this.options);
                 if (tag.contains(":")) {
                     final String[] parts = tag.split(":", 2);
                     itemStack = NbtProvider.setString(itemStack, parts[0], parts[1]);
@@ -319,7 +319,7 @@ public class MenuItem {
             }
 
             if (this.options.nbtInt().isPresent()) {
-                final String tag = holder.setPlaceholders(this.options.nbtInt().get());
+                final String tag = holder.setPlaceholdersWithOptions(this.options.nbtInt().get(), this.options);
                 if (tag.contains(":")) {
                     final String[] parts = tag.split(":");
                     itemStack = NbtProvider.setInt(itemStack, parts[0], Integer.parseInt(parts[1]));
@@ -327,7 +327,7 @@ public class MenuItem {
             }
 
             for (String nbtTag : this.options.nbtStrings()) {
-                final String tag = holder.setPlaceholders(nbtTag);
+                final String tag = holder.setPlaceholdersWithOptions(nbtTag, this.options);
                 if (tag.contains(":")) {
                     final String[] parts = tag.split(":", 2);
                     itemStack = NbtProvider.setString(itemStack, parts[0], parts[1]);
@@ -335,7 +335,7 @@ public class MenuItem {
             }
 
             for (String nbtTag : this.options.nbtInts()) {
-                final String tag = holder.setPlaceholders(nbtTag);
+                final String tag = holder.setPlaceholdersWithOptions(nbtTag, this.options);
                 if (tag.contains(":")) {
                     final String[] parts = tag.split(":");
                     itemStack = NbtProvider.setInt(itemStack, parts[0], Integer.parseInt(parts[1]));


### PR DESCRIPTION
Hello,

this PR adds the feature that you have access to the current slot of the menu item when building dynamic inventories with filler items.

I added a new function MenuHolder#setPlaceholdersWithOptions that will be called in the MenuItem#getItemStack Method to replace that placeholder with the slot from the options. I'm also calling it inside the MenuHolder when MenuItems are getting updated.

I decided to pass the whole options instead of only slot because of future placeholder additions.

_This was commissioned work by makiil.grosnach._