### PR TITLE
Add Lore Append Mode as option for menu items

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -6,10 +6,7 @@ import com.extendedclip.deluxemenus.action.ClickAction;
 import com.extendedclip.deluxemenus.action.ClickActionTask;
 import com.extendedclip.deluxemenus.action.ClickHandler;
 import com.extendedclip.deluxemenus.hooks.ItemHook;
-import com.extendedclip.deluxemenus.menu.Menu;
-import com.extendedclip.deluxemenus.menu.MenuHolder;
-import com.extendedclip.deluxemenus.menu.MenuItem;
-import com.extendedclip.deluxemenus.menu.MenuItemOptions;
+import com.extendedclip.deluxemenus.menu.*;
 import com.extendedclip.deluxemenus.requirement.*;
 import com.extendedclip.deluxemenus.requirement.wrappers.ItemWrapper;
 import com.extendedclip.deluxemenus.utils.DebugLevel;
@@ -20,16 +17,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -734,7 +722,6 @@ public class DeluxeMenusConfig {
               .customModelData(c.getString(currentPath + "model_data", null))
               .displayName(c.getString(currentPath + "display_name"))
               .lore(c.getStringList(currentPath + "lore"))
-              .originalItemLore(c.getBoolean(currentPath + "original_lore", false))
               .rgb(c.getString(currentPath + "rgb", null))
               .unbreakable(c.getBoolean(currentPath + "unbreakable", false))
               .updatePlaceholders(c.getBoolean(currentPath + "update", false))
@@ -747,6 +734,21 @@ public class DeluxeMenusConfig {
               .nbtStrings(c.getStringList(currentPath + "nbt_strings"))
               .nbtInts(c.getStringList(currentPath + "nbt_ints"))
               .priority(c.getInt(currentPath + "priority", 1));
+
+      // Lore Append Mode
+      if (c.contains(currentPath + "lore_append_mode")) {
+        String loreAppendMode = c.getString(currentPath + "lore_append_mode", "OVERRIDE").toUpperCase();
+        try {
+          builder.loreAppendMode(LoreAppendMode.valueOf(loreAppendMode.toUpperCase()));
+        } catch (IllegalArgumentException | NullPointerException ignored) {
+          DeluxeMenus.debug(
+                  DebugLevel.HIGHEST,
+                  Level.WARNING,
+                  "Lore append mode: " + loreAppendMode + " for item: " + key + " in menu: " + name
+                          + " is not a valid lore append mode!"
+          );
+        }
+      }
 
       // item flags
       if (c.contains(currentPath + "item_flags")) {

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -734,6 +734,7 @@ public class DeluxeMenusConfig {
               .customModelData(c.getString(currentPath + "model_data", null))
               .displayName(c.getString(currentPath + "display_name"))
               .lore(c.getStringList(currentPath + "lore"))
+              .originalItemLore(c.getBoolean(currentPath + "original_lore", false))
               .rgb(c.getString(currentPath + "rgb", null))
               .unbreakable(c.getBoolean(currentPath + "unbreakable", false))
               .updatePlaceholders(c.getBoolean(currentPath + "update", false))

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -740,8 +740,9 @@ public class DeluxeMenusConfig {
       if (c.contains(currentPath + "lore_append_mode")) {
         String loreAppendMode = c.getString(currentPath + "lore_append_mode", "OVERRIDE").toUpperCase();
         try {
-          builder.loreAppendMode(LoreAppendMode.valueOf(loreAppendMode.toUpperCase()));
+          builder.loreAppendMode(LoreAppendMode.valueOf(loreAppendMode));
         } catch (IllegalArgumentException | NullPointerException ignored) {
+          builder.loreAppendMode(LoreAppendMode.OVERRIDE); // Defaults to override in case of invalid append mode
           DeluxeMenus.debug(
                   DebugLevel.HIGHEST,
                   Level.WARNING,

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -722,7 +722,7 @@ public class DeluxeMenusConfig {
               .customModelData(c.getString(currentPath + "model_data", null))
               .displayName(c.getString(currentPath + "display_name"))
               .lore(c.getStringList(currentPath + "lore"))
-              .ignoreLore(c.getBoolean(currentPath + "ignore_lore", false))
+              .hasLore(c.contains(currentPath + "lore"))
               .rgb(c.getString(currentPath + "rgb", null))
               .unbreakable(c.getBoolean(currentPath + "unbreakable", false))
               .updatePlaceholders(c.getBoolean(currentPath + "update", false))

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -722,6 +722,7 @@ public class DeluxeMenusConfig {
               .customModelData(c.getString(currentPath + "model_data", null))
               .displayName(c.getString(currentPath + "display_name"))
               .lore(c.getStringList(currentPath + "lore"))
+              .ignoreLore(c.getBoolean(currentPath + "ignore_lore", false))
               .rgb(c.getString(currentPath + "rgb", null))
               .unbreakable(c.getBoolean(currentPath + "unbreakable", false))
               .updatePlaceholders(c.getBoolean(currentPath + "update", false))

--- a/src/main/java/com/extendedclip/deluxemenus/menu/LoreAppendMode.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/LoreAppendMode.java
@@ -1,0 +1,8 @@
+package com.extendedclip.deluxemenus.menu;
+
+public enum LoreAppendMode {
+    OVERRIDE,
+    BOTTOM,
+    TOP,
+    IGNORE
+}

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -26,10 +26,12 @@ import org.bukkit.potion.PotionEffect;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -25,11 +25,7 @@ import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -218,14 +214,18 @@ public class MenuItem {
         }
 
         if (!this.options.lore().isEmpty()) {
-            final List<String> lore = this.options.lore().stream()
+            List<String> lore = new ArrayList<>();
+            // This checks if a lore should be kept from the hooked item, and then if a lore exists on the item
+            if (options.originalItemLore() && itemMeta.hasLore()) lore = itemMeta.getLore();
+
+            lore.addAll(this.options.lore().stream()
                     .map(holder::setPlaceholders)
                     .map(StringUtils::color)
                     .map(line -> line.split("\n"))
                     .flatMap(Arrays::stream)
                     .map(line -> line.split("\\\\n"))
                     .flatMap(Arrays::stream)
-                    .collect(Collectors.toList());
+                    .collect(Collectors.toList()));
 
             itemMeta.setLore(lore);
         }

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -229,7 +229,7 @@ public class MenuItem {
                     case IGNORE: // DM lore is not added at all
                         lore.addAll(itemLore);
                         break;
-                    case TOP: // DM lore is added at the top
+                    case BOTTOM: // DM lore is bottom at the bottom
                         lore.addAll(itemLore);
                         lore.addAll(this.options.lore().stream()
                                 .map(holder::setPlaceholders)
@@ -240,7 +240,7 @@ public class MenuItem {
                                 .flatMap(Arrays::stream)
                                 .collect(Collectors.toList()));
                         break;
-                    case BOTTOM: // DM lore is added at the bottom
+                    case TOP: // DM lore is added at the top
                         lore.addAll(this.options.lore().stream()
                                 .map(holder::setPlaceholders)
                                 .map(StringUtils::color)

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -213,6 +213,11 @@ public class MenuItem {
             itemMeta.setDisplayName(StringUtils.color(displayName));
         }
 
+        // This removes all lore from the item if the option is enabled. Useful if you have a hooked item with lore that you don't want.
+        if (this.options.ignoreLore()) {
+            itemMeta.setLore(new ArrayList<>());
+        }
+
         if (!this.options.lore().isEmpty()) {
             List<String> lore = new ArrayList<>();
             // This checks if a lore should be kept from the hooked item, and then if a lore exists on the item

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -228,36 +228,15 @@ public class MenuItem {
                     lore.addAll(itemLore);
                     break;
                 case TOP: // DM lore is added at the top
-                    lore.addAll(this.options.lore().stream()
-                            .map(holder::setPlaceholders)
-                            .map(StringUtils::color)
-                            .map(line -> line.split("\n"))
-                            .flatMap(Arrays::stream)
-                            .map(line -> line.split("\\\\n"))
-                            .flatMap(Arrays::stream)
-                            .collect(Collectors.toList()));
+                    lore.addAll(getMenuItemLore(holder, this.options.lore()));
                     lore.addAll(itemLore);
                     break;
                 case BOTTOM: // DM lore is bottom at the bottom
                     lore.addAll(itemLore);
-                    lore.addAll(this.options.lore().stream()
-                            .map(holder::setPlaceholders)
-                            .map(StringUtils::color)
-                            .map(line -> line.split("\n"))
-                            .flatMap(Arrays::stream)
-                            .map(line -> line.split("\\\\n"))
-                            .flatMap(Arrays::stream)
-                            .collect(Collectors.toList()));
+                    lore.addAll(getMenuItemLore(holder, this.options.lore()));
                     break;
                 case OVERRIDE: // Lore from DM overrides the lore from the item
-                    lore.addAll(this.options.lore().stream()
-                            .map(holder::setPlaceholders)
-                            .map(StringUtils::color)
-                            .map(line -> line.split("\n"))
-                            .flatMap(Arrays::stream)
-                            .map(line -> line.split("\\\\n"))
-                            .flatMap(Arrays::stream)
-                            .collect(Collectors.toList()));
+                    lore.addAll(getMenuItemLore(holder, this.options.lore()));
                     break;
             }
             itemMeta.setLore(lore);
@@ -402,6 +381,17 @@ public class MenuItem {
         return DeluxeMenus.getInstance()
                 .getItemHook(hookName)
                 .map(itemHook -> itemHook.getItem(args));
+    }
+
+    private List<String> getMenuItemLore(@NotNull final MenuHolder holder, @NotNull final List<String> lore) {
+        return lore.stream()
+                .map(holder::setPlaceholders)
+                .map(StringUtils::color)
+                .map(line -> line.split("\n"))
+                .flatMap(Arrays::stream)
+                .map(line -> line.split("\\\\n"))
+                .flatMap(Arrays::stream)
+                .collect(Collectors.toList());
     }
 
     public @NotNull MenuItemOptions options() {

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -221,56 +221,44 @@ public class MenuItem {
         if (!this.options.lore().isEmpty()) {
             List<String> lore = new ArrayList<>();
             // This checks if a lore should be kept from the hooked item, and then if a lore exists on the item
-            // If an item has no lore, then don't bother with these checks. It'll always just override.
-            if (itemMeta.hasLore()) {
-                // ItemMeta.getLore is nullable, but we check if it hasLore beforehand. This *should* check for nullability, but just in case...
-                List<String> itemLore = Objects.requireNonNullElse(itemMeta.getLore(), new ArrayList<>());
-                switch (this.options.loreAppendMode()) {
-                    case IGNORE: // DM lore is not added at all
-                        lore.addAll(itemLore);
-                        break;
-                    case BOTTOM: // DM lore is bottom at the bottom
-                        lore.addAll(itemLore);
-                        lore.addAll(this.options.lore().stream()
-                                .map(holder::setPlaceholders)
-                                .map(StringUtils::color)
-                                .map(line -> line.split("\n"))
-                                .flatMap(Arrays::stream)
-                                .map(line -> line.split("\\\\n"))
-                                .flatMap(Arrays::stream)
-                                .collect(Collectors.toList()));
-                        break;
-                    case TOP: // DM lore is added at the top
-                        lore.addAll(this.options.lore().stream()
-                                .map(holder::setPlaceholders)
-                                .map(StringUtils::color)
-                                .map(line -> line.split("\n"))
-                                .flatMap(Arrays::stream)
-                                .map(line -> line.split("\\\\n"))
-                                .flatMap(Arrays::stream)
-                                .collect(Collectors.toList()));
-                        lore.addAll(itemLore);
-                        break;
-                    case OVERRIDE: // Lore from DM overrides the lore from the item
-                        lore.addAll(this.options.lore().stream()
-                                .map(holder::setPlaceholders)
-                                .map(StringUtils::color)
-                                .map(line -> line.split("\n"))
-                                .flatMap(Arrays::stream)
-                                .map(line -> line.split("\\\\n"))
-                                .flatMap(Arrays::stream)
-                                .collect(Collectors.toList()));
-                        break;
-                }
-            } else {
-                lore.addAll(this.options.lore().stream()
-                        .map(holder::setPlaceholders)
-                        .map(StringUtils::color)
-                        .map(line -> line.split("\n"))
-                        .flatMap(Arrays::stream)
-                        .map(line -> line.split("\\\\n"))
-                        .flatMap(Arrays::stream)
-                        .collect(Collectors.toList()));
+            // ItemMeta.getLore is nullable. In that case, we just create a new ArrayList so we don't add stuff to a null list.
+            List<String> itemLore = Objects.requireNonNullElse(itemMeta.getLore(), new ArrayList<>());
+            switch (this.options.loreAppendMode()) {
+                case IGNORE: // DM lore is not added at all
+                    lore.addAll(itemLore);
+                    break;
+                case TOP: // DM lore is added at the top
+                    lore.addAll(this.options.lore().stream()
+                            .map(holder::setPlaceholders)
+                            .map(StringUtils::color)
+                            .map(line -> line.split("\n"))
+                            .flatMap(Arrays::stream)
+                            .map(line -> line.split("\\\\n"))
+                            .flatMap(Arrays::stream)
+                            .collect(Collectors.toList()));
+                    lore.addAll(itemLore);
+                    break;
+                case BOTTOM: // DM lore is bottom at the bottom
+                    lore.addAll(itemLore);
+                    lore.addAll(this.options.lore().stream()
+                            .map(holder::setPlaceholders)
+                            .map(StringUtils::color)
+                            .map(line -> line.split("\n"))
+                            .flatMap(Arrays::stream)
+                            .map(line -> line.split("\\\\n"))
+                            .flatMap(Arrays::stream)
+                            .collect(Collectors.toList()));
+                    break;
+                case OVERRIDE: // Lore from DM overrides the lore from the item
+                    lore.addAll(this.options.lore().stream()
+                            .map(holder::setPlaceholders)
+                            .map(StringUtils::color)
+                            .map(line -> line.split("\n"))
+                            .flatMap(Arrays::stream)
+                            .map(line -> line.split("\\\\n"))
+                            .flatMap(Arrays::stream)
+                            .collect(Collectors.toList()));
+                    break;
             }
             itemMeta.setLore(lore);
         }

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -216,17 +216,57 @@ public class MenuItem {
         if (!this.options.lore().isEmpty()) {
             List<String> lore = new ArrayList<>();
             // This checks if a lore should be kept from the hooked item, and then if a lore exists on the item
-            if (options.originalItemLore() && itemMeta.hasLore()) lore = itemMeta.getLore();
-
-            lore.addAll(this.options.lore().stream()
-                    .map(holder::setPlaceholders)
-                    .map(StringUtils::color)
-                    .map(line -> line.split("\n"))
-                    .flatMap(Arrays::stream)
-                    .map(line -> line.split("\\\\n"))
-                    .flatMap(Arrays::stream)
-                    .collect(Collectors.toList()));
-
+            // If an item has no lore, then don't bother with these checks. It'll always just override.
+            if (itemMeta.hasLore()) {
+                // ItemMeta.getLore is nullable, but we check if it hasLore beforehand. This *should* check for nullability, but just in case...
+                List<String> itemLore = Objects.requireNonNullElse(itemMeta.getLore(), new ArrayList<>());
+                switch (this.options.originalItemLore()) {
+                    case IGNORE: // DM lore is not added at all
+                        lore.addAll(itemLore);
+                        break;
+                    case TOP: // DM lore is added at the top
+                        lore.addAll(itemLore);
+                        lore.addAll(this.options.lore().stream()
+                                .map(holder::setPlaceholders)
+                                .map(StringUtils::color)
+                                .map(line -> line.split("\n"))
+                                .flatMap(Arrays::stream)
+                                .map(line -> line.split("\\\\n"))
+                                .flatMap(Arrays::stream)
+                                .collect(Collectors.toList()));
+                        break;
+                    case BOTTOM: // DM lore is added at the bottom
+                        lore.addAll(this.options.lore().stream()
+                                .map(holder::setPlaceholders)
+                                .map(StringUtils::color)
+                                .map(line -> line.split("\n"))
+                                .flatMap(Arrays::stream)
+                                .map(line -> line.split("\\\\n"))
+                                .flatMap(Arrays::stream)
+                                .collect(Collectors.toList()));
+                        lore.addAll(itemLore);
+                        break;
+                    case OVERRIDE: // Lore from DM overrides the lore from the item
+                        lore.addAll(this.options.lore().stream()
+                                .map(holder::setPlaceholders)
+                                .map(StringUtils::color)
+                                .map(line -> line.split("\n"))
+                                .flatMap(Arrays::stream)
+                                .map(line -> line.split("\\\\n"))
+                                .flatMap(Arrays::stream)
+                                .collect(Collectors.toList()));
+                        break;
+                }
+            } else {
+                lore.addAll(this.options.lore().stream()
+                        .map(holder::setPlaceholders)
+                        .map(StringUtils::color)
+                        .map(line -> line.split("\n"))
+                        .flatMap(Arrays::stream)
+                        .map(line -> line.split("\\\\n"))
+                        .flatMap(Arrays::stream)
+                        .collect(Collectors.toList()));
+            }
             itemMeta.setLore(lore);
         }
 

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -225,7 +225,7 @@ public class MenuItem {
             if (itemMeta.hasLore()) {
                 // ItemMeta.getLore is nullable, but we check if it hasLore beforehand. This *should* check for nullability, but just in case...
                 List<String> itemLore = Objects.requireNonNullElse(itemMeta.getLore(), new ArrayList<>());
-                switch (this.options.originalItemLore()) {
+                switch (this.options.loreAppendMode()) {
                     case IGNORE: // DM lore is not added at all
                         lore.addAll(itemLore);
                         break;

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItemOptions.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItemOptions.java
@@ -310,6 +310,7 @@ public class MenuItemOptions {
                 .dynamicAmount(this.dynamicAmount)
                 .displayName(this.displayName)
                 .lore(this.lore)
+                .ignoreLore(this.ignoreLore)
                 .loreAppendMode(this.loreAppendMode)
                 .baseColor(this.baseColor)
                 .headType(this.headType)

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItemOptions.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItemOptions.java
@@ -217,7 +217,7 @@ public class MenuItemOptions {
         return ignoreLore;
     }
 
-    public LoreAppendMode originalItemLore() {
+    public LoreAppendMode loreAppendMode() {
         return loreAppendMode;
     }
 

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItemOptions.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItemOptions.java
@@ -43,6 +43,7 @@ public class MenuItemOptions {
 
     private final boolean displayNameHasPlaceholders;
     private final boolean loreHasPlaceholders;
+    private boolean originalItemLore;
 
     private final String nbtString;
     private final String nbtInt;
@@ -76,6 +77,7 @@ public class MenuItemOptions {
         this.dynamicAmount = builder.dynamicAmount;
         this.displayName = builder.displayName;
         this.lore = builder.lore;
+        this.originalItemLore = builder.originalItemLore;
         this.baseColor = builder.baseColor;
         this.headType = builder.headType;
         this.placeholderData = builder.placeholderData;
@@ -209,6 +211,10 @@ public class MenuItemOptions {
         return loreHasPlaceholders;
     }
 
+    public boolean originalItemLore() {
+        return originalItemLore;
+    }
+
     public @NotNull Optional<String> nbtString() {
         return Optional.ofNullable(nbtString);
     }
@@ -298,6 +304,7 @@ public class MenuItemOptions {
                 .dynamicAmount(this.dynamicAmount)
                 .displayName(this.displayName)
                 .lore(this.lore)
+                .originalItemLore(this.originalItemLore)
                 .baseColor(this.baseColor)
                 .headType(this.headType)
                 .placeholderData(this.placeholderData)
@@ -360,6 +367,7 @@ public class MenuItemOptions {
 
         private boolean displayNameHasPlaceholders;
         private boolean loreHasPlaceholders;
+        private boolean originalItemLore;
 
         private String nbtString;
         private String nbtInt;
@@ -524,6 +532,11 @@ public class MenuItemOptions {
 
         public MenuItemOptionsBuilder updatePlaceholders(final boolean updatePlaceholders) {
             this.updatePlaceholders = updatePlaceholders;
+            return this;
+        }
+
+        public MenuItemOptionsBuilder originalItemLore(final boolean originalItemLore) {
+            this.originalItemLore = originalItemLore;
             return this;
         }
 

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItemOptions.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItemOptions.java
@@ -43,7 +43,7 @@ public class MenuItemOptions {
 
     private final boolean displayNameHasPlaceholders;
     private final boolean loreHasPlaceholders;
-    private boolean originalItemLore;
+    private LoreAppendMode loreAppendMode;
 
     private final String nbtString;
     private final String nbtInt;
@@ -77,7 +77,7 @@ public class MenuItemOptions {
         this.dynamicAmount = builder.dynamicAmount;
         this.displayName = builder.displayName;
         this.lore = builder.lore;
-        this.originalItemLore = builder.originalItemLore;
+        this.loreAppendMode = builder.loreAppendMode;
         this.baseColor = builder.baseColor;
         this.headType = builder.headType;
         this.placeholderData = builder.placeholderData;
@@ -211,8 +211,8 @@ public class MenuItemOptions {
         return loreHasPlaceholders;
     }
 
-    public boolean originalItemLore() {
-        return originalItemLore;
+    public LoreAppendMode originalItemLore() {
+        return loreAppendMode;
     }
 
     public @NotNull Optional<String> nbtString() {
@@ -304,7 +304,7 @@ public class MenuItemOptions {
                 .dynamicAmount(this.dynamicAmount)
                 .displayName(this.displayName)
                 .lore(this.lore)
-                .originalItemLore(this.originalItemLore)
+                .loreAppendMode(this.loreAppendMode)
                 .baseColor(this.baseColor)
                 .headType(this.headType)
                 .placeholderData(this.placeholderData)
@@ -367,7 +367,7 @@ public class MenuItemOptions {
 
         private boolean displayNameHasPlaceholders;
         private boolean loreHasPlaceholders;
-        private boolean originalItemLore;
+        private LoreAppendMode loreAppendMode;
 
         private String nbtString;
         private String nbtInt;
@@ -535,8 +535,8 @@ public class MenuItemOptions {
             return this;
         }
 
-        public MenuItemOptionsBuilder originalItemLore(final boolean originalItemLore) {
-            this.originalItemLore = originalItemLore;
+        public MenuItemOptionsBuilder loreAppendMode(final LoreAppendMode loreAppendMode) {
+            this.loreAppendMode = loreAppendMode;
             return this;
         }
 

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItemOptions.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItemOptions.java
@@ -43,6 +43,7 @@ public class MenuItemOptions {
 
     private final boolean displayNameHasPlaceholders;
     private final boolean loreHasPlaceholders;
+    private final boolean ignoreLore;
     private LoreAppendMode loreAppendMode;
 
     private final String nbtString;
@@ -77,6 +78,7 @@ public class MenuItemOptions {
         this.dynamicAmount = builder.dynamicAmount;
         this.displayName = builder.displayName;
         this.lore = builder.lore;
+        this.ignoreLore = builder.ignoreLore;
         this.loreAppendMode = builder.loreAppendMode;
         this.baseColor = builder.baseColor;
         this.headType = builder.headType;
@@ -209,6 +211,10 @@ public class MenuItemOptions {
 
     public boolean loreHasPlaceholders() {
         return loreHasPlaceholders;
+    }
+
+    public boolean ignoreLore() {
+        return ignoreLore;
     }
 
     public LoreAppendMode originalItemLore() {
@@ -367,6 +373,7 @@ public class MenuItemOptions {
 
         private boolean displayNameHasPlaceholders;
         private boolean loreHasPlaceholders;
+        private boolean ignoreLore;
         private LoreAppendMode loreAppendMode;
 
         private String nbtString;
@@ -532,6 +539,11 @@ public class MenuItemOptions {
 
         public MenuItemOptionsBuilder updatePlaceholders(final boolean updatePlaceholders) {
             this.updatePlaceholders = updatePlaceholders;
+            return this;
+        }
+
+        public MenuItemOptionsBuilder ignoreLore(final boolean ignoreLore) {
+            this.ignoreLore = ignoreLore;
             return this;
         }
 

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItemOptions.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItemOptions.java
@@ -43,7 +43,7 @@ public class MenuItemOptions {
 
     private final boolean displayNameHasPlaceholders;
     private final boolean loreHasPlaceholders;
-    private final boolean ignoreLore;
+    private final boolean hasLore;
     private LoreAppendMode loreAppendMode;
 
     private final String nbtString;
@@ -78,7 +78,7 @@ public class MenuItemOptions {
         this.dynamicAmount = builder.dynamicAmount;
         this.displayName = builder.displayName;
         this.lore = builder.lore;
-        this.ignoreLore = builder.ignoreLore;
+        this.hasLore = builder.hasLore;
         this.loreAppendMode = builder.loreAppendMode;
         this.baseColor = builder.baseColor;
         this.headType = builder.headType;
@@ -213,12 +213,12 @@ public class MenuItemOptions {
         return loreHasPlaceholders;
     }
 
-    public boolean ignoreLore() {
-        return ignoreLore;
+    public boolean hasLore() {
+        return hasLore;
     }
 
-    public LoreAppendMode loreAppendMode() {
-        return loreAppendMode;
+    public @NotNull Optional<LoreAppendMode> loreAppendMode() {
+        return Optional.ofNullable(loreAppendMode);
     }
 
     public @NotNull Optional<String> nbtString() {
@@ -310,7 +310,7 @@ public class MenuItemOptions {
                 .dynamicAmount(this.dynamicAmount)
                 .displayName(this.displayName)
                 .lore(this.lore)
-                .ignoreLore(this.ignoreLore)
+                .hasLore(this.hasLore)
                 .loreAppendMode(this.loreAppendMode)
                 .baseColor(this.baseColor)
                 .headType(this.headType)
@@ -374,7 +374,7 @@ public class MenuItemOptions {
 
         private boolean displayNameHasPlaceholders;
         private boolean loreHasPlaceholders;
-        private boolean ignoreLore;
+        private boolean hasLore;
         private LoreAppendMode loreAppendMode;
 
         private String nbtString;
@@ -543,8 +543,8 @@ public class MenuItemOptions {
             return this;
         }
 
-        public MenuItemOptionsBuilder ignoreLore(final boolean ignoreLore) {
-            this.ignoreLore = ignoreLore;
+        public MenuItemOptionsBuilder hasLore(final boolean hasLore) {
+            this.hasLore = hasLore;
             return this;
         }
 


### PR DESCRIPTION
This adds the `lore_append_mode` option to items, allowing users better control over their lore. This is especially useful for servers using hooks with other plugins, as occasionally you want the items lore from those plugins but in different areas on the item in DM. An example that we ran into was our shop, were we wanted the Oraxen lore to make it easy to update DM when we change items in Oraxen. There are 4 options:

IGNORE: This makes it so that it only takes the hooked items lore
TOP: This adds the DM lore on top
BOTTOM: This adds the DM lore on the bottom
OVERRIDE: Default behavior right now, DM lore overrides hooked item lore. 


Before:
![javaw_maDFeUke5c](https://github.com/HelpChat/DeluxeMenus/assets/37521985/bdfb9698-384f-4dd5-9410-84c88e503660)

After:
![javaw_oyqoHkB4Tx](https://github.com/HelpChat/DeluxeMenus/assets/37521985/721ae3cd-d65b-46b9-9153-bde8390d445d)

Example:
```yaml
  kitchen_counter_turn:
    slot: 0
    material: oraxen-kitchen_counter_turn
    lore_append_mode: TOP
    lore:
    - ''
    - '&f$250'
 ```

Feedback is welcome and encouraged!