### PR TITLE
Added support for armor trims

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Compile only
-spigot = "1.20.2-R0.1-SNAPSHOT"
+spigot = "1.20.4-R0.1-SNAPSHOT"
 vault = "1.7.1"
 authlib = "1.5.25"
 headdb = "1.3.1"

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -6,22 +6,29 @@ import com.extendedclip.deluxemenus.action.ClickAction;
 import com.extendedclip.deluxemenus.action.ClickActionTask;
 import com.extendedclip.deluxemenus.action.ClickHandler;
 import com.extendedclip.deluxemenus.hooks.ItemHook;
-import com.extendedclip.deluxemenus.menu.*;
-import com.extendedclip.deluxemenus.requirement.*;
+import com.extendedclip.deluxemenus.menu.LoreAppendMode;
+import com.extendedclip.deluxemenus.menu.Menu;
+import com.extendedclip.deluxemenus.menu.MenuHolder;
+import com.extendedclip.deluxemenus.menu.MenuItem;
+import com.extendedclip.deluxemenus.menu.MenuItemOptions;
+import com.extendedclip.deluxemenus.requirement.HasExpRequirement;
+import com.extendedclip.deluxemenus.requirement.HasItemRequirement;
+import com.extendedclip.deluxemenus.requirement.HasMetaRequirement;
+import com.extendedclip.deluxemenus.requirement.HasMoneyRequirement;
+import com.extendedclip.deluxemenus.requirement.HasPermissionRequirement;
+import com.extendedclip.deluxemenus.requirement.InputResultRequirement;
+import com.extendedclip.deluxemenus.requirement.IsNearRequirement;
+import com.extendedclip.deluxemenus.requirement.IsObjectRequirement;
+import com.extendedclip.deluxemenus.requirement.JavascriptRequirement;
+import com.extendedclip.deluxemenus.requirement.RegexMatchesRequirement;
+import com.extendedclip.deluxemenus.requirement.Requirement;
+import com.extendedclip.deluxemenus.requirement.RequirementList;
+import com.extendedclip.deluxemenus.requirement.RequirementType;
+import com.extendedclip.deluxemenus.requirement.StringLengthRequirement;
 import com.extendedclip.deluxemenus.requirement.wrappers.ItemWrapper;
 import com.extendedclip.deluxemenus.utils.DebugLevel;
 import com.extendedclip.deluxemenus.utils.LocationUtils;
 import com.extendedclip.deluxemenus.utils.VersionHelper;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.*;
-import java.util.logging.Level;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -36,7 +43,29 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
-import static com.extendedclip.deluxemenus.utils.Constants.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.extendedclip.deluxemenus.utils.Constants.PLACEHOLDER_PREFIX;
+import static com.extendedclip.deluxemenus.utils.Constants.PLAYER_ITEMS;
+import static com.extendedclip.deluxemenus.utils.Constants.WATER_BOTTLE;
 
 public class DeluxeMenusConfig {
 
@@ -815,6 +844,11 @@ public class DeluxeMenusConfig {
             }
           }
         }
+      }
+
+      if (VersionHelper.HAS_ARMOR_TRIMS) {
+        builder.trimMaterial(c.getString(currentPath + "trim_material", null));
+        builder.trimPattern(c.getString(currentPath + "trim_pattern", null));
       }
 
       if (c.contains(currentPath + "banner_meta") && c.isList(currentPath + "banner_meta")) {

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -277,16 +277,13 @@ public class MenuItem {
             itemMeta.addItemFlags(ItemFlag.HIDE_UNBREAKABLE);
         }
 
-        final Optional<String> trimMaterialName = this.options.trimMaterial();
-        final Optional<String> trimPatternName = this.options.trimPattern();
         if (ItemUtils.hasArmorMeta(itemStack)) {
+            final Optional<String> trimMaterialName = this.options.trimMaterial();
+            final Optional<String> trimPatternName = this.options.trimPattern();
+
             if (trimMaterialName.isPresent() && trimPatternName.isPresent()) {
-                final TrimMaterial trimMaterial = Registry.TRIM_MATERIAL.get(NamespacedKey.minecraft(
-                        holder.setPlaceholdersAndArguments(trimMaterialName.get().toLowerCase(Locale.getDefault()))
-                ));
-                final TrimPattern trimPattern = Registry.TRIM_PATTERN.get(NamespacedKey.minecraft(
-                        holder.setPlaceholdersAndArguments(trimPatternName.get().toLowerCase(Locale.getDefault()))
-                ));
+                final TrimMaterial trimMaterial = Registry.TRIM_MATERIAL.match(holder.setPlaceholdersAndArguments(trimMaterialName.get()));
+                final TrimPattern trimPattern = Registry.TRIM_PATTERN.match(holder.setPlaceholdersAndArguments(trimPatternName.get()));
 
                 if (trimMaterial != null && trimPattern != null) {
                     final ArmorTrim armorTrim = new ArmorTrim(trimMaterial, trimPattern);

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -10,11 +10,14 @@ import com.extendedclip.deluxemenus.utils.VersionHelper;
 import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.block.Banner;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ArmorMeta;
 import org.bukkit.inventory.meta.BannerMeta;
 import org.bukkit.inventory.meta.BlockStateMeta;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
@@ -22,6 +25,9 @@ import org.bukkit.inventory.meta.FireworkEffectMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.inventory.meta.trim.ArmorTrim;
+import org.bukkit.inventory.meta.trim.TrimMaterial;
+import org.bukkit.inventory.meta.trim.TrimPattern;
 import org.bukkit.potion.PotionEffect;
 import org.jetbrains.annotations.NotNull;
 
@@ -269,6 +275,54 @@ public class MenuItem {
 
         if (this.options.hideUnbreakable()) {
             itemMeta.addItemFlags(ItemFlag.HIDE_UNBREAKABLE);
+        }
+
+        final Optional<String> trimMaterialName = this.options.trimMaterial();
+        final Optional<String> trimPatternName = this.options.trimPattern();
+        if (ItemUtils.hasArmorMeta(itemStack)) {
+            if (trimMaterialName.isPresent() && trimPatternName.isPresent()) {
+                final TrimMaterial trimMaterial = Registry.TRIM_MATERIAL.get(NamespacedKey.minecraft(
+                        holder.setPlaceholdersAndArguments(trimMaterialName.get().toLowerCase(Locale.getDefault()))
+                ));
+                final TrimPattern trimPattern = Registry.TRIM_PATTERN.get(NamespacedKey.minecraft(
+                        holder.setPlaceholdersAndArguments(trimPatternName.get().toLowerCase(Locale.getDefault()))
+                ));
+
+                if (trimMaterial != null && trimPattern != null) {
+                    final ArmorTrim armorTrim = new ArmorTrim(trimMaterial, trimPattern);
+                    final ArmorMeta armorMeta = (ArmorMeta) itemMeta;
+                    armorMeta.setTrim(armorTrim);
+                    itemStack.setItemMeta(armorMeta);
+                } else {
+                    if (trimMaterial == null) {
+                        DeluxeMenus.debug(
+                                DebugLevel.HIGHEST,
+                                Level.WARNING,
+                                "Trim material " + trimMaterialName.get() + " is not a valid!"
+                        );
+                    }
+
+                    if (trimPattern == null) {
+                        DeluxeMenus.debug(
+                                DebugLevel.HIGHEST,
+                                Level.WARNING,
+                                "Trim pattern " + trimPatternName.get() + " is not a valid!"
+                        );
+                    }
+                }
+            } else if (trimMaterialName.isPresent()) {
+                DeluxeMenus.debug(
+                        DebugLevel.HIGHEST,
+                        Level.WARNING,
+                        "Trim pattern is not set for item with trim material " + trimMaterialName.get()
+                );
+            } else if (trimPatternName.isPresent()) {
+                DeluxeMenus.debug(
+                        DebugLevel.HIGHEST,
+                        Level.WARNING,
+                        "Trim material is not set for item with trim pattern " + trimPatternName.get()
+                );
+            }
         }
 
         if (itemMeta instanceof LeatherArmorMeta && this.options.rgb().isPresent()) {

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItemOptions.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItemOptions.java
@@ -30,6 +30,9 @@ public class MenuItemOptions {
     private final String placeholderData;
     private final String rgb;
 
+    private final String trimMaterial;
+    private final String trimPattern;
+
     private final Map<Enchantment, Integer> enchantments;
     private final List<PotionEffect> potionEffects;
     private final List<Pattern> bannerMeta;
@@ -44,7 +47,7 @@ public class MenuItemOptions {
     private final boolean displayNameHasPlaceholders;
     private final boolean loreHasPlaceholders;
     private final boolean hasLore;
-    private LoreAppendMode loreAppendMode;
+    private final LoreAppendMode loreAppendMode;
 
     private final String nbtString;
     private final String nbtInt;
@@ -84,6 +87,8 @@ public class MenuItemOptions {
         this.headType = builder.headType;
         this.placeholderData = builder.placeholderData;
         this.rgb = builder.rgb;
+        this.trimMaterial = builder.trimMaterial;
+        this.trimPattern = builder.trimPattern;
         this.enchantments = builder.enchantments;
         this.potionEffects = builder.potionEffects;
         this.bannerMeta = builder.bannerMeta;
@@ -167,6 +172,14 @@ public class MenuItemOptions {
 
     public @NotNull Optional<String> rgb() {
         return Optional.ofNullable(rgb);
+    }
+
+    public @NotNull Optional<String> trimMaterial() {
+        return Optional.ofNullable(trimMaterial);
+    }
+
+    public @NotNull Optional<String> trimPattern() {
+        return Optional.ofNullable(trimPattern);
     }
 
     public @NotNull Map<Enchantment, Integer> enchantments() {
@@ -316,6 +329,8 @@ public class MenuItemOptions {
                 .headType(this.headType)
                 .placeholderData(this.placeholderData)
                 .rgb(this.rgb)
+                .trimMaterial(this.trimMaterial)
+                .trimPattern(this.trimPattern)
                 .enchantments(this.enchantments)
                 .potionEffects(this.potionEffects)
                 .bannerMeta(this.bannerMeta)
@@ -360,6 +375,9 @@ public class MenuItemOptions {
         private HeadType headType;
         private String placeholderData;
         private String rgb;
+
+        private String trimMaterial;
+        private String trimPattern;
 
         private Map<Enchantment, Integer> enchantments = Collections.emptyMap();
         private List<PotionEffect> potionEffects = Collections.emptyList();
@@ -460,6 +478,16 @@ public class MenuItemOptions {
 
         public MenuItemOptionsBuilder rgb(final @Nullable String rgb) {
             this.rgb = rgb;
+            return this;
+        }
+
+        public MenuItemOptionsBuilder trimMaterial(final @Nullable String trimMaterial) {
+            this.trimMaterial = trimMaterial;
+            return this;
+        }
+
+        public MenuItemOptionsBuilder trimPattern(final @Nullable String trimPattern) {
+            this.trimPattern = trimPattern;
             return this;
         }
 

--- a/src/main/java/com/extendedclip/deluxemenus/utils/ItemUtils.java
+++ b/src/main/java/com/extendedclip/deluxemenus/utils/ItemUtils.java
@@ -2,6 +2,7 @@ package com.extendedclip.deluxemenus.utils;
 
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ArmorMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionType;
@@ -66,6 +67,10 @@ public final class ItemUtils {
      */
     public static boolean isShield(@NotNull final Material material) {
         return material == Material.SHIELD;
+    }
+
+    public static boolean hasArmorMeta(@NotNull final ItemStack itemStack) {
+        return itemStack.getItemMeta() instanceof ArmorMeta;
     }
 
     /**

--- a/src/main/java/com/extendedclip/deluxemenus/utils/VersionHelper.java
+++ b/src/main/java/com/extendedclip/deluxemenus/utils/VersionHelper.java
@@ -21,6 +21,8 @@ public final class VersionHelper {
     private static final String PACKAGE_NAME = Bukkit.getServer().getClass().getPackage().getName();
     public static final String NMS_VERSION = PACKAGE_NAME.substring(PACKAGE_NAME.lastIndexOf('.') + 1);
 
+    // ArmorTrims
+    private static final int V1_20 = 1200;
     // PlayerProfile API
     private static final int V1_18_1 = 1181;
     // Mojang obfuscation changes
@@ -41,6 +43,10 @@ public final class VersionHelper {
     private static final boolean IS_PAPER = checkPaper();
 
 
+    /**
+     * Checks if the current version includes the ArmorTrims API
+     */
+    public static final boolean HAS_ARMOR_TRIMS = CURRENT_VERSION >= V1_20;
     /**
      * Checks if current version includes the PlayerProfile API
      */


### PR DESCRIPTION
This PR adds support for [ArmorTrims](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/inventory/meta/trim/ArmorTrim.html) and Closes https://github.com/HelpChat/DeluxeMenus/issues/55.

To use this new feature, 2 new options were added: `trim_material` and `trim_pattern`.
These options can be set for each item in each menu but will only work for armor items. Both of these options support placeholders and arguments. The options are also case-sensitive.

This change was tested on:
- git-Paper-365 (MC: 1.20.4)
- Java 17 (OpenJDK 64-Bit Server VM 17.0.5+8)