### PR TITLE
Added support for light levels for light item

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -722,6 +722,7 @@ public class DeluxeMenusConfig {
               .amount(c.getInt(currentPath + "amount", -1))
               .dynamicAmount(c.getString(currentPath + "dynamic_amount", null))
               .customModelData(c.getString(currentPath + "model_data", null))
+              .lightLevel(c.getString(currentPath + "light_level", null))
               .displayName(c.getString(currentPath + "display_name"))
               .lore(c.getStringList(currentPath + "lore"))
               .hasLore(c.contains(currentPath + "lore"))

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -11,11 +11,14 @@ import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
 import org.bukkit.Material;
 import org.bukkit.block.Banner;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Levelled;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BannerMeta;
+import org.bukkit.inventory.meta.BlockDataMeta;
 import org.bukkit.inventory.meta.BlockStateMeta;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.FireworkEffectMeta;
@@ -322,6 +325,26 @@ public class MenuItem {
 
         if (!(itemMeta instanceof EnchantmentStorageMeta) && !this.options.enchantments().isEmpty()) {
             itemStack.addUnsafeEnchantments(this.options.enchantments());
+        }
+
+        if (this.options.lightLevel().isPresent() && itemMeta instanceof BlockDataMeta) {
+            final BlockDataMeta blockDataMeta = (BlockDataMeta) itemStack.getItemMeta();
+            final BlockData blockData = blockDataMeta.getBlockData(itemStack.getType());
+            if (blockData instanceof Levelled) {
+                final Levelled levelled = (Levelled) blockData;
+                final String parsedLightLevel = holder.setPlaceholdersAndArguments(this.options.lightLevel().get());
+                try {
+                    final int lightLevel = Math.min(Integer.parseInt(parsedLightLevel), levelled.getMaximumLevel());
+                    levelled.setLevel(Math.max(lightLevel, 0));
+                    blockDataMeta.setBlockData(levelled);
+                    itemStack.setItemMeta(blockDataMeta);
+                } catch (final Exception exception) {
+                    DeluxeMenus.printStacktrace(
+                            "Invalid light level found for light block: " + parsedLightLevel,
+                            exception
+                    );
+                }
+            }
         }
 
         if (NbtProvider.isAvailable()) {

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -13,6 +13,7 @@ import org.bukkit.Material;
 import org.bukkit.block.Banner;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Levelled;
+import org.bukkit.block.data.type.Light;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
@@ -330,13 +331,28 @@ public class MenuItem {
         if (this.options.lightLevel().isPresent() && itemMeta instanceof BlockDataMeta) {
             final BlockDataMeta blockDataMeta = (BlockDataMeta) itemStack.getItemMeta();
             final BlockData blockData = blockDataMeta.getBlockData(itemStack.getType());
-            if (blockData instanceof Levelled) {
-                final Levelled levelled = (Levelled) blockData;
+            if (blockData instanceof Light) {
+                final Light light = (Light) blockData;
                 final String parsedLightLevel = holder.setPlaceholdersAndArguments(this.options.lightLevel().get());
                 try {
-                    final int lightLevel = Math.min(Integer.parseInt(parsedLightLevel), levelled.getMaximumLevel());
-                    levelled.setLevel(Math.max(lightLevel, 0));
-                    blockDataMeta.setBlockData(levelled);
+                    final int lightLevel = Math.min(Integer.parseInt(parsedLightLevel), light.getMaximumLevel());
+                    light.setLevel(Math.max(lightLevel, 0));
+                    if (lightLevel < 0) {
+                        DeluxeMenus.debug(
+                                DebugLevel.MEDIUM,
+                                Level.WARNING,
+                                "Invalid light level found for light block: " + parsedLightLevel + ". Setting to 0."
+                        );
+                    }
+                    if (lightLevel > light.getMaximumLevel()) {
+                        DeluxeMenus.debug(
+                                DebugLevel.MEDIUM,
+                                Level.WARNING,
+                                "Invalid light level found for light block: " + parsedLightLevel + ". Setting to " + light.getMaximumLevel() + "."
+                        );
+                    }
+
+                    blockDataMeta.setBlockData(light);
                     itemStack.setItemMeta(blockDataMeta);
                 } catch (final Exception exception) {
                     DeluxeMenus.printStacktrace(

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItemOptions.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItemOptions.java
@@ -23,6 +23,7 @@ public class MenuItemOptions {
     private final int amount;
     private final String customModelData;
     private final String dynamicAmount;
+    private final String lightLevel;
     private final String displayName;
     private final List<String> lore;
     private final DyeColor baseColor;
@@ -76,6 +77,7 @@ public class MenuItemOptions {
         this.amount = builder.amount;
         this.customModelData = builder.customModelData;
         this.dynamicAmount = builder.dynamicAmount;
+        this.lightLevel = builder.lightLevel;
         this.displayName = builder.displayName;
         this.lore = builder.lore;
         this.hasLore = builder.hasLore;
@@ -139,6 +141,10 @@ public class MenuItemOptions {
 
     public @NotNull Optional<String> dynamicAmount() {
         return Optional.ofNullable(dynamicAmount);
+    }
+
+    public @NotNull Optional<String> lightLevel() {
+        return Optional.ofNullable(lightLevel);
     }
 
     public @NotNull Optional<String> displayName() {
@@ -308,6 +314,7 @@ public class MenuItemOptions {
                 .amount(this.amount)
                 .customModelData(this.customModelData)
                 .dynamicAmount(this.dynamicAmount)
+                .lightLevel(this.lightLevel)
                 .displayName(this.displayName)
                 .lore(this.lore)
                 .hasLore(this.hasLore)
@@ -354,6 +361,7 @@ public class MenuItemOptions {
         private int amount;
         private String customModelData;
         private String dynamicAmount;
+        private String lightLevel;
         private String displayName;
         private List<String> lore = Collections.emptyList();
         private DyeColor baseColor;
@@ -426,6 +434,11 @@ public class MenuItemOptions {
 
         public MenuItemOptionsBuilder dynamicAmount(final @Nullable String configDynamicAmount) {
             this.dynamicAmount = configDynamicAmount;
+            return this;
+        }
+
+        public MenuItemOptionsBuilder lightLevel(final @Nullable String lightLevel) {
+            this.lightLevel = lightLevel;
             return this;
         }
 


### PR DESCRIPTION
This change adds support for customizing the light level of a [Light](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/block/data/type/Light.html) item. This can be done with the new `light_level` option that can take as value an integer or a placeholder.

This change was tested on:

    git-Paper-365 (MC: 1.20.4)
    Java 17 (OpenJDK 64-Bit Server VM 17.0.5+8)

Closes #23 