### PR TITLE
Issue/80

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
+++ b/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
@@ -58,8 +58,12 @@ public class ClickActionTask extends BukkitRunnable {
         }
 
         final Optional<MenuHolder> holder = Menu.getMenuHolder(player);
-        final String executable = StringUtils.replacePlaceholdersAndArguments(this.exec, this.arguments, player, this.parsePlaceholdersInArguments);
 
+        final Player target = holder.isPresent() && holder.get().getPlaceholderPlayer() != null
+                ? holder.get().getPlaceholderPlayer()
+                : player;
+
+        final String executable = StringUtils.replacePlaceholdersAndArguments(this.exec, this.arguments, target, this.parsePlaceholdersInArguments);
 
         switch (actionType) {
             case META:
@@ -405,14 +409,14 @@ public class ClickActionTask extends BukkitRunnable {
 
                 switch (actionType) {
                     case BROADCAST_SOUND:
-                        for (final Player target : Bukkit.getOnlinePlayers()) {
-                            target.playSound(target.getLocation(), sound, volume, pitch);
+                        for (final Player broadcastTarget : Bukkit.getOnlinePlayers()) {
+                            broadcastTarget.playSound(broadcastTarget.getLocation(), sound, volume, pitch);
                         }
                         break;
 
                     case BROADCAST_WORLD_SOUND:
-                        for (final Player target : player.getWorld().getPlayers()) {
-                            target.playSound(target.getLocation(), sound, volume, pitch);
+                        for (final Player broadcastTarget : player.getWorld().getPlayers()) {
+                            broadcastTarget.playSound(broadcastTarget.getLocation(), sound, volume, pitch);
                         }
                         break;
 


### PR DESCRIPTION
**NOTE: This PR is built on top of #64. Please merge that one before merging this one.**

When opening a menu with `/dm open <menu> [viewer] -p:<target>`, the target should be used to parse all placeholders. This was the case for menu title, item name, item lore, item amount, action chance, action delay, and everywhere else except for actions.

Closes #80 

Tested on:
```
This server is running Paper version git-Paper-496 (MC: 1.20.4) (Implementing API version 1.20.4-R0.1-SNAPSHOT) (Git: 7ac24a1 on ver/1.20.4)
You are running the latest version
Previous version: git-Paper-365 (MC: 1.20.4)
```

Tested menu title, item lore, item name, broadcast action:
![image](https://github.com/HelpChat/DeluxeMenus/assets/52609756/62c33459-2bee-41d9-b5b4-76a939f20ad0)
