### PR TITLE
Issue/78

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
+++ b/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
@@ -33,6 +33,7 @@ public class ClickActionTask extends BukkitRunnable {
     // Ugly hack to get around the fact that arguments are not available at task execution time
     private final Map<String, String> arguments;
     private final boolean parsePlaceholdersInArguments;
+    private final boolean parsePlaceholdersAfterArguments;
 
     public ClickActionTask(
             @NotNull final DeluxeMenus plugin,
@@ -40,7 +41,8 @@ public class ClickActionTask extends BukkitRunnable {
             @NotNull final ActionType actionType,
             @NotNull final String exec,
             @NotNull final Map<String, String> arguments,
-            final boolean parsePlaceholdersInArguments
+            final boolean parsePlaceholdersInArguments,
+            final boolean parsePlaceholdersAfterArguments
     ) {
         this.plugin = plugin;
         this.uuid = uuid;
@@ -48,6 +50,7 @@ public class ClickActionTask extends BukkitRunnable {
         this.exec = exec;
         this.arguments = arguments;
         this.parsePlaceholdersInArguments = parsePlaceholdersInArguments;
+        this.parsePlaceholdersAfterArguments = parsePlaceholdersAfterArguments;
     }
 
     @Override
@@ -58,7 +61,12 @@ public class ClickActionTask extends BukkitRunnable {
         }
 
         final Optional<MenuHolder> holder = Menu.getMenuHolder(player);
-        final String executable = StringUtils.replacePlaceholdersAndArguments(this.exec, this.arguments, player, this.parsePlaceholdersInArguments);
+        final String executable = StringUtils.replacePlaceholdersAndArguments(
+                this.exec,
+                this.arguments,
+                player,
+                this.parsePlaceholdersInArguments,
+                this.parsePlaceholdersAfterArguments);
 
 
         switch (actionType) {

--- a/src/main/java/com/extendedclip/deluxemenus/commands/DeluxeMenusCommands.java
+++ b/src/main/java/com/extendedclip/deluxemenus/commands/DeluxeMenusCommands.java
@@ -182,6 +182,7 @@ public class DeluxeMenusCommands implements CommandExecutor {
                     action.getType(),
                     action.getExecutable(),
                     holder.getTypedArgs(),
+                    true,
                     true
                 );
 

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -666,11 +666,8 @@ public class DeluxeMenusConfig {
             return;
         }
 
-        final boolean argumentsSupportPlaceholders = c.getBoolean(pre + "arguments_support_placeholders", false);
-
-        if (argumentsSupportPlaceholders) {
-            builder.parsePlaceholdersInArguments(argumentsSupportPlaceholders);
-        }
+        builder.parsePlaceholdersInArguments(c.getBoolean(pre + "arguments_support_placeholders", false));
+        builder.parsePlaceholdersAfterArguments(c.getBoolean(pre + "parse_placeholders_after_arguments", false));
 
         // Don't need to register the menu since it's done in the constructor
         new Menu(builder.build(), items);
@@ -1489,7 +1486,8 @@ public class DeluxeMenusConfig {
                                 action.getType(),
                                 action.getExecutable(),
                                 holder.getTypedArgs(),
-                                holder.parsePlaceholdersInArguments()
+                                holder.parsePlaceholdersInArguments(),
+                                holder.parsePlaceholdersAfterArguments()
                         );
 
                         if (action.hasDelay()) {

--- a/src/main/java/com/extendedclip/deluxemenus/menu/Menu.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/Menu.java
@@ -337,6 +337,7 @@ public class Menu extends Command {
         }
         holder.setTypedArgs(args);
         holder.parsePlaceholdersInArguments(this.options.parsePlaceholdersInArguments());
+        holder.parsePlaceholdersAfterArguments(this.options.parsePlaceholdersAfterArguments());
 
         if (!this.handleArgRequirements(holder)) {
             return;

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
@@ -31,6 +31,7 @@ public class MenuHolder implements InventoryHolder {
     private Inventory inventory;
     private boolean updating;
     private boolean parsePlaceholdersInArguments;
+    private boolean parsePlaceholdersAfterArguments;
     private Map<String, String> typedArgs;
 
     public MenuHolder(Player viewer) {
@@ -91,6 +92,9 @@ public class MenuHolder implements InventoryHolder {
     }
 
     public @NotNull String setPlaceholdersAndArguments(final @NotNull String string) {
+        if (parsePlaceholdersAfterArguments) {
+            return setPlaceholders(setArguments(string));
+        }
         return setArguments(setPlaceholders(string));
     }
 
@@ -318,8 +322,16 @@ public class MenuHolder implements InventoryHolder {
         this.parsePlaceholdersInArguments = parsePlaceholdersInArguments;
     }
 
+    public void parsePlaceholdersAfterArguments(final boolean parsePlaceholdersAfterArguments) {
+        this.parsePlaceholdersAfterArguments = parsePlaceholdersAfterArguments;
+    }
+
     public boolean parsePlaceholdersInArguments() {
         return parsePlaceholdersInArguments;
+    }
+
+    public boolean parsePlaceholdersAfterArguments() {
+        return parsePlaceholdersAfterArguments;
     }
 
     public void setPlaceholderPlayer(Player placeholderPlayer) {

--- a/src/main/java/com/extendedclip/deluxemenus/menu/options/MenuOptions.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/options/MenuOptions.java
@@ -17,6 +17,7 @@ public class MenuOptions {
     private final int size;
     private final int updateInterval;
     private final boolean parsePlaceholdersInArguments;
+    private final boolean parsePlaceholdersAfterArguments;
 
     private final List<String> commands;
     private final boolean registerCommands;
@@ -35,6 +36,7 @@ public class MenuOptions {
         this.size = builder.size;
         this.updateInterval = builder.updateInterval;
         this.parsePlaceholdersInArguments = builder.parsePlaceholdersInArguments;
+        this.parsePlaceholdersAfterArguments = builder.parsePlaceholdersAfterArguments;
 
         this.commands = builder.commands;
         this.registerCommands = builder.registerCommands;
@@ -75,6 +77,10 @@ public class MenuOptions {
         return this.parsePlaceholdersInArguments;
     }
 
+    public boolean parsePlaceholdersAfterArguments() {
+        return this.parsePlaceholdersAfterArguments;
+    }
+
     public @NotNull List<@NotNull String> commands() {
         return this.commands;
     }
@@ -113,6 +119,7 @@ public class MenuOptions {
                 .size(this.size)
                 .updateInterval(this.updateInterval)
                 .parsePlaceholdersInArguments(this.parsePlaceholdersInArguments)
+                .parsePlaceholdersAfterArguments(this.parsePlaceholdersAfterArguments)
                 .commands(this.commands)
                 .registerCommands(this.registerCommands)
                 .arguments(this.arguments)
@@ -131,6 +138,7 @@ public class MenuOptions {
         private int size = 9;
         private int updateInterval = 10;
         private boolean parsePlaceholdersInArguments = false;
+        private boolean parsePlaceholdersAfterArguments = false;
 
         private List<String> commands = List.of();
         private boolean registerCommands = false;
@@ -174,6 +182,11 @@ public class MenuOptions {
 
         public MenuOptionsBuilder parsePlaceholdersInArguments(final boolean parsePlaceholdersInArguments) {
             this.parsePlaceholdersInArguments = parsePlaceholdersInArguments;
+            return this;
+        }
+
+        public MenuOptionsBuilder parsePlaceholdersAfterArguments(final boolean parsePlaceholdersAfterArguments) {
+            this.parsePlaceholdersAfterArguments = parsePlaceholdersAfterArguments;
             return this;
         }
 

--- a/src/main/java/com/extendedclip/deluxemenus/utils/StringUtils.java
+++ b/src/main/java/com/extendedclip/deluxemenus/utils/StringUtils.java
@@ -38,9 +38,15 @@ public class StringUtils {
 
     @NotNull
     public static String replacePlaceholdersAndArguments(@NotNull String input, final @Nullable Map<String, String> arguments,
-                                                         final @Nullable Player player, boolean parsePlaceholdersInsideArguments) {
+                                                         final @Nullable Player player,
+                                                         final boolean parsePlaceholdersInsideArguments,
+                                                         final boolean parsePlaceholdersAfterArguments) {
         if (player == null) {
             return replaceArguments(input, arguments, null, parsePlaceholdersInsideArguments);
+        }
+
+        if (parsePlaceholdersAfterArguments) {
+            return replacePlaceholders(replaceArguments(input, arguments, player, parsePlaceholdersInsideArguments), player);
         }
 
         return replaceArguments(replacePlaceholders(input, player), arguments, player, parsePlaceholdersInsideArguments);


### PR DESCRIPTION
**NOTE: This PR is built on top of #64. Please merge that one before merging this one.**

This fixes a side effect of our changes regarding parsing placeholders inside arguments.

We have previously made some changes to how arguments and placeholders are handled.
How it used to work:

    Parse Arguments
    Parse Placeholders

How it works now:

    Parse placeholders
    If enabled, parse placeholders inside arguments
    Parse arguments

These changes were made because we've realized that letting players parse arbitrary placeholders is bad. In my opinion, placeholders should be simple mapping operations without any side effects. Not everyone agrees or sticks by this rule. Some placeholders do things such as giving items to players, executing commands, etc. when they are parsed.

When I've made the changes, I have allowed menu designers to enable placeholder parsing inside arguments on a per-menu basis. I have missed that parsing arguments after parsing placeholders, does not allow menu designers to use arguments inside placeholders anymore.

This PR fixes this by adding a new per menu option `parse_placeholders_after_arguments`. This option defaults to the false value and this is how it would work:

If `parse_placeholders_after_arguments` is disabled:
```
    Parse placeholders
    If enabled, parse placeholders inside arguments
    Parse arguments
```

If `parse_placeholders_after_arguments` is enabled:
```
    If enabled, parse placeholders inside arguments
    Parse arguments
    Parse placeholders
```

Enabling this option reverts to parsing working how it was before. We are giving menu designers the choice of taking risks but we are disabling the option by default.

Closes #78 

Tested on:
```
This server is running Paper version git-Paper-496 (MC: 1.20.4) (Implementing API version 1.20.4-R0.1-SNAPSHOT) (Git: 7ac24a1 on ver/1.20.4)
You are running the latest version
Previous version: git-Paper-365 (MC: 1.20.4)
```

Tested with a simple ParseOther + Vault placeholder and a `player` argument. As it can be seen, with the new option disabled, the placeholder returns the default value from the vault placeholder since it tries to parse the placeholder for the argument key (`{player}`) and not the value of the argument. This is fixed with the new option enabled.
![image](https://github.com/HelpChat/DeluxeMenus/assets/52609756/c8b93f88-7ef1-458b-a92a-b6afa23ae37b)
![image](https://github.com/HelpChat/DeluxeMenus/assets/52609756/cc2d43f0-44e2-41af-a8f6-00fd60c242f3)
![image](https://github.com/HelpChat/DeluxeMenus/assets/52609756/3052ce09-b875-4946-87ef-e8da5b1c2637)


