### PR TITLE
fix: item flags not working in 1.20.5+ & deprecate hide_ options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gradle
 .idea
 build
+test-server/

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -1117,13 +1117,14 @@ public class DeluxeMenusConfig {
                 continue;
             }
 
-            RequirementType type = RequirementType.getType(c.getString(rPath + ".type"));
+            String stringType = c.getString(rPath + ".type");
+            RequirementType type = RequirementType.getType(stringType);
 
             if (type == null) {
                 DeluxeMenus.debug(
                         DebugLevel.HIGHEST,
                         Level.WARNING,
-                        "Requirement type at path: " + rPath + " is not a valid requirement type!"
+                        "Requirement type '" + stringType + "' at path '" + rPath + "' is not valid!"
                 );
                 continue;
             }

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -23,6 +23,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -33,6 +34,7 @@ import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.banner.PatternType;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -731,6 +733,8 @@ public class DeluxeMenusConfig {
                 );
                 continue;
             }
+
+            checkForDeprecatedItemOptions(c.getConfigurationSection(currentPath), name);
 
             MenuItemOptions.MenuItemOptionsBuilder builder = MenuItemOptions.builder()
                     .material(material)
@@ -1515,6 +1519,27 @@ public class DeluxeMenusConfig {
         }
 
         return handler;
+    }
+
+    private void checkForDeprecatedItemOptions(ConfigurationSection config, String menuName) {
+        final BiConsumer<String, ItemFlag> oldItemFlagOptionCheck = (option, itemFlag) -> {
+            if (!config.contains(option)) {
+                return;
+            }
+
+            DeluxeMenus.debug(
+                DebugLevel.HIGHEST,
+                Level.WARNING,
+                String.format(
+                    "Option '%s' of item '%s' in menu '%s' is deprecated and will be removed in the future. Replace it with item_flags: [%s].",
+                    option, config.getName(), menuName, itemFlag
+                )
+            );
+        };
+
+        oldItemFlagOptionCheck.accept("hide_attributes", ItemFlag.HIDE_ATTRIBUTES);
+        oldItemFlagOptionCheck.accept("hide_enchantments", ItemFlag.HIDE_ENCHANTS);
+        oldItemFlagOptionCheck.accept("hide_unbreakable", ItemFlag.HIDE_UNBREAKABLE);
     }
 
     public void debug(String... messages) {

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -230,7 +230,7 @@ public class MenuItem {
         // This checks if a lore should be kept from the hooked item, and then if a lore exists on the item
         // ItemMeta.getLore is nullable. In that case, we just create a new ArrayList so we don't add stuff to a null list.
         List<String> itemLore = Objects.requireNonNullElse(itemMeta.getLore(), new ArrayList<>());
-        // Ensures backwards compadibility with how hooked items are currently handled
+        // Ensures backwards compatibility with how hooked items are currently handled
         LoreAppendMode mode = this.options.loreAppendMode().orElse(LoreAppendMode.OVERRIDE);
         if (!this.options.hasLore() && this.options.loreAppendMode().isEmpty()) mode = LoreAppendMode.IGNORE;
         switch (mode) {
@@ -252,26 +252,8 @@ public class MenuItem {
 
         itemMeta.setLore(lore);
 
-        if (!this.options.itemFlags().isEmpty()) {
-            for (final ItemFlag flag : this.options.itemFlags()) {
-                itemMeta.addItemFlags(flag);
-            }
-        }
-
-        if (this.options.hideAttributes()) {
-            itemMeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-        }
-
-        if (this.options.hideEnchants()) {
-            itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        }
-
         if (this.options.unbreakable()) {
             itemMeta.setUnbreakable(true);
-        }
-
-        if (this.options.hideUnbreakable()) {
-            itemMeta.addItemFlags(ItemFlag.HIDE_UNBREAKABLE);
         }
 
         if (VersionHelper.HAS_ARMOR_TRIMS && ItemUtils.hasArmorMeta(itemStack)) {
@@ -369,7 +351,7 @@ public class MenuItem {
         }
 
         if (!(itemMeta instanceof EnchantmentStorageMeta) && !this.options.enchantments().isEmpty()) {
-            itemStack.addUnsafeEnchantments(this.options.enchantments());
+            this.options.enchantments().forEach((enchantment, level) -> itemMeta.addEnchant(enchantment, level, true));
         }
 
         if (this.options.lightLevel().isPresent() && itemMeta instanceof BlockDataMeta) {
@@ -406,6 +388,18 @@ public class MenuItem {
                 }
             }
         }
+
+        if (!this.options.itemFlags().isEmpty()) {
+            for (final ItemFlag flag : this.options.itemFlags()) {
+                itemMeta.addItemFlags(flag);
+
+                if (flag == ItemFlag.HIDE_ATTRIBUTES && VersionHelper.HAS_DATA_COMPONENTS) {
+                    itemMeta.setAttributeModifiers(null);
+                }
+            }
+        }
+
+        itemStack.setItemMeta(itemMeta);
 
         if (NbtProvider.isAvailable()) {
             if (this.options.nbtString().isPresent()) {

--- a/src/main/java/com/extendedclip/deluxemenus/menu/options/MenuItemOptions.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/options/MenuItemOptions.java
@@ -12,10 +12,13 @@ import org.bukkit.potion.PotionEffect;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public class MenuItemOptions {
 
@@ -38,12 +41,9 @@ public class MenuItemOptions {
     private final Map<Enchantment, Integer> enchantments;
     private final List<PotionEffect> potionEffects;
     private final List<Pattern> bannerMeta;
-    private final List<ItemFlag> itemFlags;
+    private final Set<ItemFlag> itemFlags = new HashSet<>();
 
     private final boolean unbreakable;
-    private final boolean hideAttributes;
-    private final boolean hideEnchants;
-    private final boolean hideUnbreakable;
 
     private final boolean displayNameHasPlaceholders;
     private final boolean loreHasPlaceholders;
@@ -94,11 +94,8 @@ public class MenuItemOptions {
         this.enchantments = builder.enchantments;
         this.potionEffects = builder.potionEffects;
         this.bannerMeta = builder.bannerMeta;
-        this.itemFlags = builder.itemFlags;
+        this.itemFlags.addAll(builder.itemFlags);
         this.unbreakable = builder.unbreakable;
-        this.hideAttributes = builder.hideAttributes;
-        this.hideEnchants = builder.hideEnchants;
-        this.hideUnbreakable = builder.hideUnbreakable;
         this.displayNameHasPlaceholders = builder.displayNameHasPlaceholders;
         this.loreHasPlaceholders = builder.loreHasPlaceholders;
         this.nbtString = builder.nbtString;
@@ -199,24 +196,12 @@ public class MenuItemOptions {
         return bannerMeta;
     }
 
-    public @NotNull List<ItemFlag> itemFlags() {
+    public @NotNull Set<ItemFlag> itemFlags() {
         return itemFlags;
     }
 
     public boolean unbreakable() {
         return unbreakable;
-    }
-
-    public boolean hideAttributes() {
-        return hideAttributes;
-    }
-
-    public boolean hideEnchants() {
-        return hideEnchants;
-    }
-
-    public boolean hideUnbreakable() {
-        return hideUnbreakable;
     }
 
     public boolean displayNameHasPlaceholders() {
@@ -338,9 +323,6 @@ public class MenuItemOptions {
                 .bannerMeta(this.bannerMeta)
                 .itemFlags(this.itemFlags)
                 .unbreakable(this.unbreakable)
-                .hideAttributes(this.hideAttributes)
-                .hideEnchants(this.hideEnchants)
-                .hideUnbreakable(this.hideUnbreakable)
                 .nbtString(this.nbtString)
                 .nbtInt(this.nbtInt)
                 .nbtStrings(this.nbtStrings)
@@ -384,12 +366,9 @@ public class MenuItemOptions {
         private Map<Enchantment, Integer> enchantments = Collections.emptyMap();
         private List<PotionEffect> potionEffects = Collections.emptyList();
         private List<Pattern> bannerMeta = Collections.emptyList();
-        private List<ItemFlag> itemFlags = Collections.emptyList();
+        private final Set<ItemFlag> itemFlags = new HashSet<>();
 
         private boolean unbreakable;
-        private boolean hideAttributes;
-        private boolean hideEnchants;
-        private boolean hideUnbreakable;
 
         private boolean displayNameHasPlaceholders;
         private boolean loreHasPlaceholders;
@@ -512,8 +491,8 @@ public class MenuItemOptions {
             return this;
         }
 
-        public MenuItemOptionsBuilder itemFlags(final @NotNull List<ItemFlag> itemFlags) {
-            this.itemFlags = itemFlags;
+        public MenuItemOptionsBuilder itemFlags(final @NotNull Collection<ItemFlag> itemFlags) {
+            this.itemFlags.addAll(itemFlags);
             return this;
         }
 
@@ -522,18 +501,36 @@ public class MenuItemOptions {
             return this;
         }
 
+        /**
+         * @deprecated Use {@link #itemFlags(Collection)} with {@link ItemFlag#HIDE_ATTRIBUTES}
+         */
+        @Deprecated()
         public MenuItemOptionsBuilder hideAttributes(final boolean hideAttributes) {
-            this.hideAttributes = hideAttributes;
+            if (hideAttributes) {
+                this.itemFlags.add(ItemFlag.HIDE_ATTRIBUTES);
+            }
             return this;
         }
 
+        /**
+         * @deprecated Use {@link #itemFlags(Collection)} with {@link ItemFlag#HIDE_ENCHANTS}
+         */
+        @Deprecated
         public MenuItemOptionsBuilder hideEnchants(final boolean hideEnchants) {
-            this.hideEnchants = hideEnchants;
+            if (hideEnchants) {
+                this.itemFlags.add(ItemFlag.HIDE_ENCHANTS);
+            }
             return this;
         }
 
+        /**
+         * @deprecated Use {@link #itemFlags(Collection)} with {@link ItemFlag#HIDE_UNBREAKABLE}
+         */
+        @Deprecated
         public MenuItemOptionsBuilder hideUnbreakable(final boolean hideUnbreakable) {
-            this.hideUnbreakable = hideUnbreakable;
+            if (hideUnbreakable) {
+                this.itemFlags.add(ItemFlag.HIDE_UNBREAKABLE);
+            }
             return this;
         }
 

--- a/src/main/java/com/extendedclip/deluxemenus/utils/VersionHelper.java
+++ b/src/main/java/com/extendedclip/deluxemenus/utils/VersionHelper.java
@@ -21,6 +21,8 @@ public final class VersionHelper {
     private static final String PACKAGE_NAME = Bukkit.getServer().getClass().getPackage().getName();
     public static final String NMS_VERSION = PACKAGE_NAME.substring(PACKAGE_NAME.lastIndexOf('.') + 1);
 
+    // Data components
+    private static final int V1_20_5 = 1_20_5;
     // ArmorTrims
     private static final int V1_19_4 = 1194;
     // PlayerProfile API
@@ -42,6 +44,10 @@ public final class VersionHelper {
 
     private static final boolean IS_PAPER = checkPaper();
 
+    /**
+     * Checks if the current version includes the <a href="https://minecraft.wiki/w/Data_component_format">Data Components</a>
+     */
+    public static final boolean HAS_DATA_COMPONENTS = CURRENT_VERSION >= V1_20_5;
 
     /**
      * Checks if the current version includes the ArmorTrims API

--- a/src/main/resources/advanced_menu.yml
+++ b/src/main/resources/advanced_menu.yml
@@ -23,7 +23,8 @@ items:
     slot: 11
     priority: 1
     update: true
-    hide_attributes: true
+    item_flags:
+      - HIDE_ATTRIBUTES
     display_name: '&bExample Kit'
     lore:
       - ''
@@ -46,7 +47,8 @@ items:
     slot: 11
     priority: 2
     update: true
-    hide_attributes: true
+    item_flags:
+      - HIDE_ATTRIBUTES
     display_name: '&cExample Kit Unavailable'
     lore:
       - '&7This kit is on cooldown!'
@@ -62,7 +64,8 @@ items:
     slot: 11
     priority: 3
     update: true
-    hide_attributes: true
+    item_flags:
+      - HIDE_ATTRIBUTES
     display_name: '&7Example Kit'
     lore:
       - '&7You do not have permission for this kit!'


### PR DESCRIPTION
This PR fixes the following issues:
- Fix #115
- Fix #116 
It also deprecates the `hide_(attributes/enchantments/unbreakable)` item options in favor of `item_flags`. Users will receive a warning message in console
> Option 'hide_unbreakable' of item 'aaa' in menu 'basics_menu' is deprecated and will be removed in the future. Replace it with item_flags: [HIDE_UNBREAKABLE].

I've also improved the _unknown requirement type_ warning by also printing the value from config for easier debug.