### PR TITLE
New `damage` option to replace `data` and swapping to the DamageAPI

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -15,6 +15,7 @@ import com.extendedclip.deluxemenus.menu.options.MenuOptions;
 import com.extendedclip.deluxemenus.requirement.*;
 import com.extendedclip.deluxemenus.requirement.wrappers.ItemWrapper;
 import com.extendedclip.deluxemenus.utils.DebugLevel;
+import com.extendedclip.deluxemenus.utils.ItemUtils;
 import com.extendedclip.deluxemenus.utils.LocationUtils;
 import com.extendedclip.deluxemenus.utils.VersionHelper;
 
@@ -797,30 +798,7 @@ public class DeluxeMenusConfig {
                 builder.itemFlags(itemFlags);
             }
 
-            if (c.contains(currentPath + "data")) {
-                if (c.isInt(currentPath + "data")) {
-                    builder.data((short) c.getInt(currentPath + "data"));
-                } else {
-                    String dataString = c.getString(currentPath + "data", "");
-                    if (dataString.startsWith("placeholder-")) {
-                        String[] parts = dataString.split("-", 2);
-                        if (parts.length < 2) {
-                            DeluxeMenus.debug(
-                                    DebugLevel.HIGHEST,
-                                    Level.WARNING,
-                                    "Placeholder for data in item: " + key + " in menu " + name + " is not the valid format!",
-                                    "Valid format: placeholder-<placeholder>",
-                                    "Skipping item: " + key
-                            );
-                            continue;
-                        }
-
-                        if (containsPlaceholders(parts[1])) {
-                            builder.placeholderData(parts[1]);
-                        }
-                    }
-                }
-            }
+            addDamageOptionToBuilder(c, currentPath, key, name, builder);
 
             if (VersionHelper.HAS_ARMOR_TRIMS) {
                 builder.trimMaterial(c.getString(currentPath + "trim_material", null));
@@ -1538,5 +1516,73 @@ public class DeluxeMenusConfig {
 
     public File getMenuDirector() {
         return menuDirectory;
+    }
+
+    public void addDamageOptionToBuilder(FileConfiguration c, String currentPath, String itemKey, String menuName,
+                                         MenuItemOptions.MenuItemOptionsBuilder builder) {
+        boolean damageOptionIsPresent = false;
+        String damageValue = null;
+
+        String key = "damage";
+        if (c.contains(currentPath + key)) {
+            damageOptionIsPresent = true;
+            damageValue = c.getString(currentPath + key, "");
+        }
+
+        key = "data";
+        if (c.contains(currentPath + key)) {
+            if (!damageOptionIsPresent) {
+                DeluxeMenus.debug(
+                        DebugLevel.HIGHEST,
+                        Level.WARNING,
+                        "Found 'data' option for item: " + itemKey + " in menu: " + menuName+ ". This option " +
+                                "is deprecated and will be removed soon. Please use 'damage' instead."
+                );
+                damageValue = c.getString(currentPath + key, "");
+            } else {
+                DeluxeMenus.debug(
+                        DebugLevel.HIGHEST,
+                        Level.WARNING,
+                        "Found 'data' and 'damage' option for item: " + itemKey + " in menu: " + menuName +
+                                ". 'data' option is deprecated and will be ignored. Using 'damage' instead."
+                );
+            }
+        }
+
+        if (damageValue == null) {
+            return;
+        }
+
+        if (damageOptionIsPresent) {
+            key = "damage";
+        }
+
+        if (!ItemUtils.isPlaceholderOption(damageValue)) {
+            DeluxeMenus.debug(
+                DebugLevel.HIGHEST,
+                Level.WARNING,
+                "Found invalid value for '" + key + "' option for item: " + itemKey + " in menu: " +
+                        menuName + ".",
+                "The correct formats for '" + key + "' are:",
+                "  -> <number>",
+                "  -> placeholder-<placeholder>",
+                "Ignoring the invalid value."
+            );
+            return;
+        }
+
+        final String[] parts = damageValue.split("-", 2);
+        if (parts.length < 2 || !containsPlaceholders(parts[1])) {
+            DeluxeMenus.debug(
+                DebugLevel.HIGHEST,
+                Level.WARNING,
+                "Could not find placeholder for '" + key + "' option for item: " + itemKey + " in menu: " +
+                        menuName + ".",
+                "Ignoring the invalid value."
+            );
+            return;
+        }
+
+        builder.damage(parts[1]);
     }
 }

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Enums;
+import com.google.common.primitives.Ints;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -1543,7 +1544,7 @@ public class DeluxeMenusConfig {
                 DeluxeMenus.debug(
                         DebugLevel.HIGHEST,
                         Level.WARNING,
-                        "Found 'data' and 'damage' option for item: " + itemKey + " in menu: " + menuName +
+                        "Found 'data' and 'damage' options for item: " + itemKey + " in menu: " + menuName +
                                 ". 'data' option is deprecated and will be ignored. Using 'damage' instead."
                 );
             }
@@ -1557,7 +1558,7 @@ public class DeluxeMenusConfig {
             key = "damage";
         }
 
-        if (!ItemUtils.isPlaceholderOption(damageValue)) {
+        if (!ItemUtils.isPlaceholderOption(damageValue) && Ints.tryParse(damageValue) == null) {
             DeluxeMenus.debug(
                 DebugLevel.HIGHEST,
                 Level.WARNING,
@@ -1572,7 +1573,7 @@ public class DeluxeMenusConfig {
         }
 
         final String[] parts = damageValue.split("-", 2);
-        if (parts.length < 2 || !containsPlaceholders(parts[1])) {
+        if (parts.length >= 2 && !containsPlaceholders(parts[1])) {
             DeluxeMenus.debug(
                 DebugLevel.HIGHEST,
                 Level.WARNING,
@@ -1583,6 +1584,6 @@ public class DeluxeMenusConfig {
             return;
         }
 
-        builder.damage(parts[1]);
+        builder.damage(parts.length == 1 ? parts[0] : parts[1]);
     }
 }

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -24,6 +24,7 @@ import org.bukkit.inventory.meta.ArmorMeta;
 import org.bukkit.inventory.meta.BannerMeta;
 import org.bukkit.inventory.meta.BlockDataMeta;
 import org.bukkit.inventory.meta.BlockStateMeta;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.FireworkEffectMeta;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -65,7 +66,7 @@ public class MenuItem {
         String stringMaterial = this.options.material();
         String lowercaseStringMaterial = stringMaterial.toLowerCase(Locale.ROOT);
 
-        if (ItemUtils.isPlaceholderMaterial(lowercaseStringMaterial)) {
+        if (ItemUtils.isPlaceholderOption(lowercaseStringMaterial)) {
             stringMaterial = holder.setPlaceholdersAndArguments(stringMaterial.substring(PLACEHOLDER_PREFIX.length()));
             lowercaseStringMaterial = stringMaterial.toLowerCase(Locale.ENGLISH);
         }
@@ -172,22 +173,23 @@ public class MenuItem {
             return itemStack;
         }
 
-        short data = this.options.data();
-
-        if (this.options.placeholderData().isPresent()) {
-            final String parsedData = holder.setPlaceholdersAndArguments(this.options.placeholderData().get());
+        if (this.options.damage().isPresent()) {
+            final String parsedDamage = holder.setPlaceholdersAndArguments(this.options.damage().get());
             try {
-                data = Short.parseShort(parsedData);
+                int damage = Integer.parseInt(parsedDamage);
+                if (damage > 0) {
+                    final ItemMeta meta = itemStack.getItemMeta();
+                    if (meta instanceof Damageable) {
+                        ((Damageable) meta).setDamage(damage);
+                        itemStack.setItemMeta(meta);
+                    }
+                }
             } catch (final NumberFormatException exception) {
                 DeluxeMenus.printStacktrace(
-                        "Invalid placeholder data found: " + parsedData + ".",
+                        "Invalid damage found: " + parsedDamage + ".",
                         exception
                 );
             }
-        }
-
-        if (data > 0) {
-            itemStack.setDurability(data);
         }
 
         if (this.options.amount() != -1) {

--- a/src/main/java/com/extendedclip/deluxemenus/menu/options/MenuItemOptions.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/options/MenuItemOptions.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 public class MenuItemOptions {
 
     private final String material;
-    private final short data;
+    private final String damage;
     private final int amount;
     private final String customModelData;
     private final String dynamicAmount;
@@ -29,7 +29,6 @@ public class MenuItemOptions {
     private final List<String> lore;
     private final DyeColor baseColor;
     private HeadType headType;
-    private final String placeholderData;
     private final String rgb;
 
     private final String trimMaterial;
@@ -76,7 +75,7 @@ public class MenuItemOptions {
 
     private MenuItemOptions(final @NotNull MenuItemOptionsBuilder builder) {
         this.material = builder.material;
-        this.data = builder.data;
+        this.damage = builder.damage;
         this.amount = builder.amount;
         this.customModelData = builder.customModelData;
         this.dynamicAmount = builder.dynamicAmount;
@@ -87,7 +86,6 @@ public class MenuItemOptions {
         this.loreAppendMode = builder.loreAppendMode;
         this.baseColor = builder.baseColor;
         this.headType = builder.headType;
-        this.placeholderData = builder.placeholderData;
         this.rgb = builder.rgb;
         this.trimMaterial = builder.trimMaterial;
         this.trimPattern = builder.trimPattern;
@@ -131,8 +129,8 @@ public class MenuItemOptions {
         return material;
     }
 
-    public short data() {
-        return data;
+    public @NotNull Optional<String> damage() {
+        return Optional.ofNullable(damage);
     }
 
     public int amount() {
@@ -169,10 +167,6 @@ public class MenuItemOptions {
 
     public @NotNull Optional<HeadType> headType() {
         return Optional.ofNullable(headType);
-    }
-
-    public @NotNull Optional<String> placeholderData() {
-        return Optional.ofNullable(placeholderData);
     }
 
     public @NotNull Optional<String> rgb() {
@@ -318,7 +312,7 @@ public class MenuItemOptions {
     public @NotNull MenuItemOptionsBuilder asBuilder() {
         return MenuItemOptions.builder()
                 .material(this.material)
-                .data(this.data)
+                .damage(this.damage)
                 .amount(this.amount)
                 .customModelData(this.customModelData)
                 .dynamicAmount(this.dynamicAmount)
@@ -329,7 +323,6 @@ public class MenuItemOptions {
                 .loreAppendMode(this.loreAppendMode)
                 .baseColor(this.baseColor)
                 .headType(this.headType)
-                .placeholderData(this.placeholderData)
                 .rgb(this.rgb)
                 .trimMaterial(this.trimMaterial)
                 .trimPattern(this.trimPattern)
@@ -366,7 +359,7 @@ public class MenuItemOptions {
     public static class MenuItemOptionsBuilder {
 
         private String material;
-        private short data;
+        private String damage;
         private int amount;
         private String customModelData;
         private String dynamicAmount;
@@ -375,7 +368,6 @@ public class MenuItemOptions {
         private List<String> lore = Collections.emptyList();
         private DyeColor baseColor;
         private HeadType headType;
-        private String placeholderData;
         private String rgb;
 
         private String trimMaterial;
@@ -428,8 +420,8 @@ public class MenuItemOptions {
             return this;
         }
 
-        public MenuItemOptionsBuilder data(final short configData) {
-            this.data = configData;
+        public MenuItemOptionsBuilder damage(final @Nullable String configDamage) {
+            this.damage = configDamage;
             return this;
         }
 
@@ -474,11 +466,6 @@ public class MenuItemOptions {
 
         public MenuItemOptionsBuilder headType(final @Nullable HeadType headType) {
             this.headType = headType;
-            return this;
-        }
-
-        public MenuItemOptionsBuilder placeholderData(final @Nullable String placeholderData) {
-            this.placeholderData = placeholderData;
             return this;
         }
 

--- a/src/main/java/com/extendedclip/deluxemenus/utils/ItemUtils.java
+++ b/src/main/java/com/extendedclip/deluxemenus/utils/ItemUtils.java
@@ -7,6 +7,8 @@ import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionType;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Locale;
+
 import static com.extendedclip.deluxemenus.utils.Constants.INVENTORY_ITEM_ACCESSORS;
 import static com.extendedclip.deluxemenus.utils.Constants.PLACEHOLDER_PREFIX;
 import static com.extendedclip.deluxemenus.utils.Constants.WATER_BOTTLE;
@@ -18,13 +20,13 @@ public final class ItemUtils {
     }
 
     /**
-     * Checks if the string starts with the substring "placeholder-". The check is case-sensitive.
+     * Checks if the string starts with the substring "placeholder-". The check is case-insensitive.
      *
      * @param material The string to check
      * @return true if the string starts with "placeholder-", false otherwise
      */
-    public static boolean isPlaceholderMaterial(@NotNull final String material) {
-        return material.startsWith(PLACEHOLDER_PREFIX);
+    public static boolean isPlaceholderOption(@NotNull final String material) {
+        return material.toLowerCase(Locale.ROOT).startsWith(PLACEHOLDER_PREFIX);
     }
 
     /**


### PR DESCRIPTION
This PR removes usage of deprecate damage/data API and makes use of the more modern one that took its place. Tested in Minecraft 1.21 with Java 21.

Fixes #67 