### PR TITLE
Add support for ItemHooks in Has Item requirement

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     compileOnly(libs.headdb)
     compileOnly(libs.itemsadder)
     compileOnly(libs.oraxen)
+    compileOnly(libs.mythiclib)
     compileOnly(libs.mmoitems)
     compileOnly(libs.score)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,8 @@ authlib = "1.5.25"
 headdb = "1.3.1"
 itemsadder = "3.2.5"
 oraxen = "1.159.0"
-mmoitems = "6.9.4-SNAPSHOT"
+mythiclib = "1.6.2-SNAPSHOT"
+mmoitems = "6.9.5-SNAPSHOT"
 papi = "2.11.6"
 score = "4.23.10.8"
 
@@ -23,6 +24,7 @@ authlib = { module = "com.mojang:authlib", version.ref = "authlib" }
 headdb = { module = "com.arcaniax:HeadDatabase-API", version.ref = "headdb" }
 itemsadder = { module = "com.github.LoneDev6:api-itemsadder", version.ref = "itemsadder" }
 oraxen = { module = "com.github.oraxen:oraxen", version.ref = "oraxen" }
+mythiclib = { module = "io.lumine:MythicLib-dist", version.ref = "mythiclib"}
 mmoitems = { module = "net.Indyuce:MMOItems-API", version.ref = "mmoitems" }
 papi = { module = "me.clip:placeholderapi", version.ref = "papi" }
 score = { module = "com.github.Ssomar-Developement:SCore", version.ref = "score" }

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -1056,9 +1056,14 @@ public class DeluxeMenusConfig {
                 case DOES_NOT_HAVE_ITEM:
                     ItemWrapper wrapper = new ItemWrapper();
                     if (c.contains(rPath + ".material")) {
+                        String materialName = c.getString(rPath + ".material");
                         try {
-                            if (!containsPlaceholders(c.getString(rPath + ".material")))
-                                Material.valueOf(c.getString(rPath + ".material").toUpperCase());
+                            if (!containsPlaceholders(materialName) && plugin.getItemHooks().values()
+                                    .stream()
+                                    .filter(x -> materialName.startsWith(x.getPrefix()))
+                                    .findFirst()
+                                    .orElse(null) == null)
+                                Material.valueOf(materialName.toUpperCase());
                         } catch (Exception ex) {
                             DeluxeMenus.debug(
                                     DebugLevel.HIGHEST,
@@ -1067,7 +1072,7 @@ public class DeluxeMenusConfig {
                             );
                             break;
                         }
-                        wrapper.setMaterial(c.getString(rPath + ".material"));
+                        wrapper.setMaterial(materialName);
                     } else {
                         DeluxeMenus.debug(
                                 DebugLevel.HIGHEST,

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -1060,7 +1060,7 @@ public class DeluxeMenusConfig {
                         try {
                             if (!containsPlaceholders(materialName) && plugin.getItemHooks().values()
                                     .stream()
-                                    .filter(x -> materialName.startsWith(x.getPrefix()))
+                                    .filter(x -> materialName.toLowerCase().startsWith(x.getPrefix()))
                                     .findFirst()
                                     .orElse(null) == null)
                                 Material.valueOf(materialName.toUpperCase());

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/BaseHeadHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/BaseHeadHook.java
@@ -32,7 +32,7 @@ public class BaseHeadHook implements ItemHook, SimpleCache {
   }
 
   @Override
-  public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+  public boolean itemMatchesIdentifiers(@NotNull ItemStack item, @NotNull String... arguments) {
     if (arguments.length == 0) {
       return false;
     }

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/BaseHeadHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/BaseHeadHook.java
@@ -37,7 +37,7 @@ public class BaseHeadHook implements ItemHook, SimpleCache {
     if (arguments.length == 0) {
       return false;
     }
-    ItemStack skull = SkullUtils.getSkullByBase64EncodedTextureUrl(arguments[0]);
+    ItemStack skull = cache.computeIfAbsent(arguments[0], SkullUtils::getSkullByBase64EncodedTextureUrl).clone();
     return Bukkit.getItemFactory().equals(item.getItemMeta(), skull.getItemMeta());
   }
 

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/BaseHeadHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/BaseHeadHook.java
@@ -6,6 +6,7 @@ import com.extendedclip.deluxemenus.utils.SkullUtils;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.bukkit.Bukkit;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,6 +30,15 @@ public class BaseHeadHook implements ItemHook, SimpleCache {
     }
 
     return DeluxeMenus.getInstance().getHead().clone();
+  }
+
+  @Override
+  public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+    if (arguments.length == 0) {
+      return false;
+    }
+    ItemStack skull = SkullUtils.getSkullByBase64EncodedTextureUrl(arguments[0]);
+    return Bukkit.getItemFactory().equals(item.getItemMeta(), skull.getItemMeta());
   }
 
   @Override

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/BaseHeadHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/BaseHeadHook.java
@@ -6,7 +6,6 @@ import com.extendedclip.deluxemenus.utils.SkullUtils;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.bukkit.Bukkit;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -37,8 +36,12 @@ public class BaseHeadHook implements ItemHook, SimpleCache {
     if (arguments.length == 0) {
       return false;
     }
-    ItemStack skull = cache.computeIfAbsent(arguments[0], SkullUtils::getSkullByBase64EncodedTextureUrl).clone();
-    return Bukkit.getItemFactory().equals(item.getItemMeta(), skull.getItemMeta());
+    String itemTexture = SkullUtils.getTextureFromSkull(item);
+    String texture = SkullUtils.decodeSkinUrl(arguments[0]);
+    if (itemTexture == null || texture == null) return false;
+
+    texture = texture.substring("https://textures.minecraft.net/texture/".length()-1);
+    return texture.equals(itemTexture);
   }
 
   @Override

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/ExecutableBlocksHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/ExecutableBlocksHook.java
@@ -29,7 +29,7 @@ public class ExecutableBlocksHook implements ItemHook, SimpleCache {
   }
 
   @Override
-  public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+  public boolean itemMatchesIdentifiers(@NotNull ItemStack item, @NotNull String... arguments) {
     return false;
   }
 

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/ExecutableBlocksHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/ExecutableBlocksHook.java
@@ -29,6 +29,11 @@ public class ExecutableBlocksHook implements ItemHook, SimpleCache {
   }
 
   @Override
+  public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+    return false;
+  }
+
+  @Override
   public String getPrefix() {
     return "executableblocks-";
   }

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/ExecutableItemsHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/ExecutableItemsHook.java
@@ -5,6 +5,8 @@ import com.ssomar.score.api.executableitems.ExecutableItemsAPI;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+
+import com.ssomar.score.api.executableitems.config.ExecutableItemInterface;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -29,6 +31,16 @@ public class ExecutableItemsHook implements ItemHook, SimpleCache {
     });
 
     return (item == null) ? new ItemStack(Material.STONE) : item.clone();
+  }
+
+  @Override
+  public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+    if (arguments.length == 0) {
+      return false;
+    }
+    ExecutableItemInterface fromId = ExecutableItemsAPI.getExecutableItemsManager().getExecutableItem(arguments[0]).orElse(null);
+    ExecutableItemInterface fromItem = ExecutableItemsAPI.getExecutableItemsManager().getExecutableItem(item).orElse(null);
+    return fromItem != null && fromItem.equals(fromId);
   }
 
   @Override

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/ExecutableItemsHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/ExecutableItemsHook.java
@@ -34,7 +34,7 @@ public class ExecutableItemsHook implements ItemHook, SimpleCache {
   }
 
   @Override
-  public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+  public boolean itemMatchesIdentifiers(@NotNull ItemStack item, @NotNull String... arguments) {
     if (arguments.length == 0) {
       return false;
     }

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/HeadDatabaseHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/HeadDatabaseHook.java
@@ -33,7 +33,7 @@ public class HeadDatabaseHook implements ItemHook {
   }
 
   @Override
-  public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+  public boolean itemMatchesIdentifiers(@NotNull ItemStack item, @NotNull String... arguments) {
     if (arguments.length == 0) {
       return false;
     }

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/HeadDatabaseHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/HeadDatabaseHook.java
@@ -33,6 +33,14 @@ public class HeadDatabaseHook implements ItemHook {
   }
 
   @Override
+  public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+    if (arguments.length == 0) {
+      return false;
+    }
+    return arguments[0].equalsIgnoreCase(api.getItemID(item));
+  }
+
+  @Override
   public String getPrefix() {
     return "hdb-";
   }

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/ItemHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/ItemHook.java
@@ -7,7 +7,7 @@ public interface ItemHook {
 
   ItemStack getItem(@NotNull final String... arguments);
 
-  boolean isItem(@NotNull ItemStack item, @NotNull final String... arguments);
+  boolean itemMatchesIdentifiers(@NotNull ItemStack item, @NotNull final String... arguments);
 
   String getPrefix();
 

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/ItemHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/ItemHook.java
@@ -7,6 +7,8 @@ public interface ItemHook {
 
   ItemStack getItem(@NotNull final String... arguments);
 
+  boolean isItem(@NotNull ItemStack item, @NotNull final String... arguments);
+
   String getPrefix();
 
 }

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/ItemsAdderHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/ItemsAdderHook.java
@@ -37,7 +37,7 @@ public class ItemsAdderHook implements ItemHook, SimpleCache {
     }
 
     @Override
-    public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+    public boolean itemMatchesIdentifiers(@NotNull ItemStack item, @NotNull String... arguments) {
         if (arguments.length == 0) {
             return false;
         }

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/ItemsAdderHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/ItemsAdderHook.java
@@ -37,6 +37,15 @@ public class ItemsAdderHook implements ItemHook, SimpleCache {
     }
 
     @Override
+    public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+        if (arguments.length == 0) {
+            return false;
+        }
+        CustomStack stack = CustomStack.byItemStack(item);
+        return stack != null && stack.getId().equalsIgnoreCase(arguments[0]);
+    }
+
+    @Override
     public String getPrefix() {
         return "itemsadder-";
     }

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/MMOItemsHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/MMOItemsHook.java
@@ -61,7 +61,7 @@ public class MMOItemsHook implements ItemHook, SimpleCache {
     }
 
     @Override
-    public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+    public boolean itemMatchesIdentifiers(@NotNull ItemStack item, @NotNull String... arguments) {
         if (arguments.length == 0) {
             return false;
         }

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/MMOItemsHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/MMOItemsHook.java
@@ -61,6 +61,16 @@ public class MMOItemsHook implements ItemHook, SimpleCache {
     }
 
     @Override
+    public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+        if (arguments.length == 0) {
+            return false;
+        }
+        String[] splitArgs = arguments[0].split(":");
+        if (splitArgs.length != 2) return false;
+        return splitArgs[0].equalsIgnoreCase(MMOItems.getTypeName(item)) && splitArgs[1].equalsIgnoreCase(MMOItems.getID(item));
+    }
+
+    @Override
     public String getPrefix() {
         return "mmoitems-";
     }

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/NamedHeadHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/NamedHeadHook.java
@@ -44,7 +44,7 @@ public class NamedHeadHook implements ItemHook, Listener, SimpleCache {
     }
 
     @Override
-    public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+    public boolean itemMatchesIdentifiers(@NotNull ItemStack item, @NotNull String... arguments) {
         if (arguments.length == 0) {
             return false;
         }

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/NamedHeadHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/NamedHeadHook.java
@@ -48,18 +48,7 @@ public class NamedHeadHook implements ItemHook, Listener, SimpleCache {
         if (arguments.length == 0) {
             return false;
         }
-        if (!(item.getItemMeta() instanceof SkullMeta)) return false;
-        final SkullMeta headMeta = (SkullMeta) item.getItemMeta();
-
-        String owner;
-        if (!VersionHelper.IS_SKULL_OWNER_LEGACY) {
-            if (headMeta.getOwningPlayer() == null) return false;
-            owner = headMeta.getOwningPlayer().getName();
-        } else {
-            owner = headMeta.getOwner();
-            if (owner == null) return false;
-        }
-        return arguments[0].equalsIgnoreCase(owner);
+        return arguments[0].equalsIgnoreCase(SkullUtils.getSkullOwner(item));
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/NamedHeadHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/NamedHeadHook.java
@@ -6,10 +6,14 @@ import com.extendedclip.deluxemenus.utils.SkullUtils;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.extendedclip.deluxemenus.utils.VersionHelper;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
 import org.jetbrains.annotations.NotNull;
 
 public class NamedHeadHook implements ItemHook, Listener, SimpleCache {
@@ -37,6 +41,25 @@ public class NamedHeadHook implements ItemHook, Listener, SimpleCache {
         }
 
         return DeluxeMenus.getInstance().getHead().clone();
+    }
+
+    @Override
+    public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+        if (arguments.length == 0) {
+            return false;
+        }
+        if (!(item.getItemMeta() instanceof SkullMeta)) return false;
+        final SkullMeta headMeta = (SkullMeta) item.getItemMeta();
+
+        String owner;
+        if (!VersionHelper.IS_SKULL_OWNER_LEGACY) {
+            if (headMeta.getOwningPlayer() == null) return false;
+            owner = headMeta.getOwningPlayer().getName();
+        } else {
+            owner = headMeta.getOwner();
+            if (owner == null) return false;
+        }
+        return arguments[0].equalsIgnoreCase(owner);
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/OraxenHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/OraxenHook.java
@@ -29,6 +29,14 @@ public class OraxenHook implements ItemHook, SimpleCache {
     }
 
     @Override
+    public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+        if (arguments.length == 0) {
+            return false;
+        }
+        return arguments[0].equalsIgnoreCase(OraxenItems.getIdByItem(item));
+    }
+
+    @Override
     public String getPrefix() {
         return "oraxen-";
     }

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/OraxenHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/OraxenHook.java
@@ -29,7 +29,7 @@ public class OraxenHook implements ItemHook, SimpleCache {
     }
 
     @Override
-    public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+    public boolean itemMatchesIdentifiers(@NotNull ItemStack item, @NotNull String... arguments) {
         if (arguments.length == 0) {
             return false;
         }

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/TextureHeadHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/TextureHeadHook.java
@@ -6,6 +6,7 @@ import com.extendedclip.deluxemenus.utils.SkullUtils;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.bukkit.Bukkit;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,6 +30,15 @@ public class TextureHeadHook implements ItemHook, SimpleCache {
     }
 
     return DeluxeMenus.getInstance().getHead().clone();
+  }
+
+  @Override
+  public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+    if (arguments.length == 0) {
+      return false;
+    }
+    ItemStack skull = SkullUtils.getSkullByBase64EncodedTextureUrl(arguments[0]);
+    return Bukkit.getItemFactory().equals(item.getItemMeta(), skull.getItemMeta());
   }
 
   @Override

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/TextureHeadHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/TextureHeadHook.java
@@ -32,7 +32,7 @@ public class TextureHeadHook implements ItemHook, SimpleCache {
   }
 
   @Override
-  public boolean isItem(@NotNull ItemStack item, @NotNull String... arguments) {
+  public boolean itemMatchesIdentifiers(@NotNull ItemStack item, @NotNull String... arguments) {
     if (arguments.length == 0) {
       return false;
     }

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/TextureHeadHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/TextureHeadHook.java
@@ -37,7 +37,7 @@ public class TextureHeadHook implements ItemHook, SimpleCache {
     if (arguments.length == 0) {
       return false;
     }
-    ItemStack skull = SkullUtils.getSkullByBase64EncodedTextureUrl(arguments[0]);
+    ItemStack skull = cache.computeIfAbsent(arguments[0], key -> SkullUtils.getSkullByBase64EncodedTextureUrl(SkullUtils.getEncoded(key))).clone();
     return Bukkit.getItemFactory().equals(item.getItemMeta(), skull.getItemMeta());
   }
 

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/TextureHeadHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/TextureHeadHook.java
@@ -6,7 +6,6 @@ import com.extendedclip.deluxemenus.utils.SkullUtils;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.bukkit.Bukkit;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -37,8 +36,7 @@ public class TextureHeadHook implements ItemHook, SimpleCache {
     if (arguments.length == 0) {
       return false;
     }
-    ItemStack skull = cache.computeIfAbsent(arguments[0], key -> SkullUtils.getSkullByBase64EncodedTextureUrl(SkullUtils.getEncoded(key))).clone();
-    return Bukkit.getItemFactory().equals(item.getItemMeta(), skull.getItemMeta());
+    return arguments[0].equals(SkullUtils.getTextureFromSkull(item));
   }
 
   @Override

--- a/src/main/java/com/extendedclip/deluxemenus/requirement/HasItemRequirement.java
+++ b/src/main/java/com/extendedclip/deluxemenus/requirement/HasItemRequirement.java
@@ -30,7 +30,7 @@ public class HasItemRequirement extends Requirement {
     if (material == null) {
       pluginHook = DeluxeMenus.getInstance().getItemHooks().values()
               .stream()
-              .filter(x -> materialName.startsWith(x.getPrefix()))
+              .filter(x -> materialName.toLowerCase().startsWith(x.getPrefix()))
               .findFirst()
               .orElse(null);
       if (pluginHook == null) return invert;

--- a/src/main/java/com/extendedclip/deluxemenus/requirement/HasItemRequirement.java
+++ b/src/main/java/com/extendedclip/deluxemenus/requirement/HasItemRequirement.java
@@ -24,8 +24,8 @@ public class HasItemRequirement extends Requirement {
 
   @Override
   public boolean evaluate(MenuHolder holder) {
-    String materialName = holder.setPlaceholdersAndArguments(wrapper.getMaterial()).toUpperCase();
-    Material material = DeluxeMenus.MATERIALS.get(materialName);
+    String materialName = holder.setPlaceholdersAndArguments(wrapper.getMaterial());
+    Material material = DeluxeMenus.MATERIALS.get(materialName.toUpperCase());
     ItemHook pluginHook = null;
     if (material == null) {
       pluginHook = DeluxeMenus.getInstance().getItemHooks().values()
@@ -68,8 +68,10 @@ public class HasItemRequirement extends Requirement {
   private boolean isRequiredItem(ItemStack itemToCheck, MenuHolder holder, Material material, ItemHook pluginHook) {
     if (itemToCheck == null || itemToCheck.getType() == Material.AIR) return false;
 
-    if (pluginHook != null && !pluginHook.isItem(itemToCheck, holder.setPlaceholdersAndArguments(wrapper.getMaterial().substring(pluginHook.getPrefix().length())))) return false;
-    if (wrapper.getMaterial() != null && itemToCheck.getType() != material) return false;
+    if (pluginHook != null) {
+      if (!pluginHook.isItem(itemToCheck, holder.setPlaceholdersAndArguments(wrapper.getMaterial().substring(pluginHook.getPrefix().length())))) return false;
+    }
+    else if (wrapper.getMaterial() != null && itemToCheck.getType() != material) return false;
     if (wrapper.hasData() && itemToCheck.getDurability() != wrapper.getData()) return false;
 
     ItemMeta metaToCheck = itemToCheck.getItemMeta();

--- a/src/main/java/com/extendedclip/deluxemenus/requirement/HasItemRequirement.java
+++ b/src/main/java/com/extendedclip/deluxemenus/requirement/HasItemRequirement.java
@@ -69,7 +69,7 @@ public class HasItemRequirement extends Requirement {
     if (itemToCheck == null || itemToCheck.getType() == Material.AIR) return false;
 
     if (pluginHook != null) {
-      if (!pluginHook.isItem(itemToCheck, holder.setPlaceholdersAndArguments(wrapper.getMaterial().substring(pluginHook.getPrefix().length())))) return false;
+      if (!pluginHook.itemMatchesIdentifiers(itemToCheck, holder.setPlaceholdersAndArguments(wrapper.getMaterial().substring(pluginHook.getPrefix().length())))) return false;
     }
     else if (wrapper.getMaterial() != null && itemToCheck.getType() != material) return false;
     if (wrapper.hasData() && itemToCheck.getDurability() != wrapper.getData()) return false;

--- a/src/main/java/com/extendedclip/deluxemenus/utils/SkullUtils.java
+++ b/src/main/java/com/extendedclip/deluxemenus/utils/SkullUtils.java
@@ -145,6 +145,18 @@ public class SkullUtils {
     return head;
   }
 
+  public static String getSkullOwner(ItemStack skull) {
+    if (skull == null || !(skull.getItemMeta() instanceof SkullMeta)) return null;
+    SkullMeta meta = (SkullMeta) skull.getItemMeta();
+
+    if (!VersionHelper.IS_SKULL_OWNER_LEGACY) {
+      if (meta.getOwningPlayer() == null) return null;
+      return meta.getOwningPlayer().getName();
+    }
+
+    return meta.getOwner();
+  }
+
   /**
    * Create a game profile object
    *

--- a/src/main/java/com/extendedclip/deluxemenus/utils/SkullUtils.java
+++ b/src/main/java/com/extendedclip/deluxemenus/utils/SkullUtils.java
@@ -80,6 +80,41 @@ public class SkullUtils {
     return head;
   }
 
+  public static String getTextureFromSkull(ItemStack item) {
+    if (!(item.getItemMeta() instanceof SkullMeta)) return null;
+    SkullMeta meta = (SkullMeta) item.getItemMeta();
+
+    if (VersionHelper.HAS_PLAYER_PROFILES) {
+      PlayerProfile profile = meta.getOwnerProfile();
+      if (profile == null) return null;
+
+      URL url = profile.getTextures().getSkin();
+      if (url == null) return null;
+
+      return url.toString().substring("https://textures.minecraft.net/texture/".length()-1);
+    }
+
+    GameProfile profile;
+    try {
+      final Field profileField = meta.getClass().getDeclaredField("profile");
+      profileField.setAccessible(true);
+      profile = (GameProfile) profileField.get(meta);
+    } catch (final NoSuchFieldException | IllegalArgumentException | IllegalAccessException exception) {
+      DeluxeMenus.printStacktrace(
+              "Failed to get base64 texture url from head item",
+              exception
+      );
+      return null;
+    }
+
+    for (Property property : profile.getProperties().get("textures")) {
+      if (property.getName().equals("textures")) {
+        return decodeSkinUrl(property.getValue());
+      }
+    }
+    return null;
+  }
+
 
   /**
    * Get the skull from a player name
@@ -164,7 +199,7 @@ public class SkullUtils {
    * @return the url of the texture if found, otherwise {@code null}
    */
   @Nullable
-  private static String decodeSkinUrl(@NotNull final String base64Texture) {
+  public static String decodeSkinUrl(@NotNull final String base64Texture) {
     final String decoded = new String(Base64.getDecoder().decode(base64Texture));
     final JsonObject object = GSON.fromJson(decoded, JsonObject.class);
 


### PR DESCRIPTION
Examples:
```yml
    <type>_requirement:
      requirements:
        item:
          type: "has item"
          material: head-Tanguygab
          material: texture-f3d5e43de5d4177c4baf2f44161554473a3b0be5430998b5fcd826af943afe3
          material: basehead-eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZjNkNWU0M2RlNWQ0MTc3YzRiYWYyZjQ0MTYxNTU0NDczYTNiMGJlNTQzMDk5OGI1ZmNkODI2YWY5NDNhZmUzIn19fQ==
          material: mmoitems-<type>:<id>
          material: itemsadder-<id>
```
Confirmed head, texture and basehead working, and got confirmation for mmoitems.
Others should work as well but if anyone is willing to check for ItemsAdder, HDB, Oraxen and ExecutableItems, that'd be nice 