### PR TITLE
feat: add options for NBT Short tags

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -759,8 +759,10 @@ public class DeluxeMenusConfig {
                     .hideUnbreakable(c.getBoolean(currentPath + "hide_unbreakable", false))
                     .hideEnchants(c.getBoolean(currentPath + "hide_enchantments", false))
                     .nbtString(c.getString(currentPath + "nbt_string", null))
+                    .nbtShort(c.getString(currentPath + "nbt_short", null))
                     .nbtInt(c.getString(currentPath + "nbt_int", null))
                     .nbtStrings(c.getStringList(currentPath + "nbt_strings"))
+                    .nbtShorts(c.getStringList(currentPath + "nbt_shorts"))
                     .nbtInts(c.getStringList(currentPath + "nbt_ints"))
                     .priority(c.getInt(currentPath + "priority", 1));
 

--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -413,6 +413,14 @@ public class MenuItem {
                 }
             }
 
+            if (this.options.nbtShort().isPresent()) {
+                final String tag = holder.setPlaceholdersAndArguments(this.options.nbtShort().get());
+                if (tag.contains(":")) {
+                    final String[] parts = tag.split(":");
+                    itemStack = NbtProvider.setShort(itemStack, parts[0], Short.parseShort(parts[1]));
+                }
+            }
+
             if (this.options.nbtInt().isPresent()) {
                 final String tag = holder.setPlaceholdersAndArguments(this.options.nbtInt().get());
                 if (tag.contains(":")) {
@@ -426,6 +434,14 @@ public class MenuItem {
                 if (tag.contains(":")) {
                     final String[] parts = tag.split(":", 2);
                     itemStack = NbtProvider.setString(itemStack, parts[0], parts[1]);
+                }
+            }
+
+            for (String nbtTag : this.options.nbtShorts()) {
+                final String tag = holder.setPlaceholdersAndArguments(nbtTag);
+                if (tag.contains(":")) {
+                    final String[] parts = tag.split(":");
+                    itemStack = NbtProvider.setShort(itemStack, parts[0], Short.parseShort(parts[1]));
                 }
             }
 

--- a/src/main/java/com/extendedclip/deluxemenus/menu/options/MenuItemOptions.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/options/MenuItemOptions.java
@@ -50,8 +50,10 @@ public class MenuItemOptions {
     private final LoreAppendMode loreAppendMode;
 
     private final String nbtString;
+    private final String nbtShort;
     private final String nbtInt;
     private final List<String> nbtStrings;
+    private final List<String> nbtShorts;
     private final List<String> nbtInts;
 
     private final int slot;
@@ -97,8 +99,10 @@ public class MenuItemOptions {
         this.displayNameHasPlaceholders = builder.displayNameHasPlaceholders;
         this.loreHasPlaceholders = builder.loreHasPlaceholders;
         this.nbtString = builder.nbtString;
+        this.nbtShort = builder.nbtShort;
         this.nbtInt = builder.nbtInt;
         this.nbtStrings = builder.nbtStrings;
+        this.nbtShorts = builder.nbtShorts;
         this.nbtInts = builder.nbtInts;
         this.slot = builder.slot;
         this.priority = builder.priority;
@@ -218,12 +222,20 @@ public class MenuItemOptions {
         return Optional.ofNullable(nbtString);
     }
 
+    public @NotNull Optional<String> nbtShort() {
+        return Optional.ofNullable(nbtShort);
+    }
+
     public @NotNull Optional<String> nbtInt() {
         return Optional.ofNullable(nbtInt);
     }
 
     public @NotNull List<String> nbtStrings() {
         return nbtStrings;
+    }
+
+    public @NotNull List<String> nbtShorts() {
+        return nbtShorts;
     }
 
     public @NotNull List<String> nbtInts() {
@@ -317,8 +329,10 @@ public class MenuItemOptions {
                 .itemFlags(this.itemFlags)
                 .unbreakable(this.unbreakable)
                 .nbtString(this.nbtString)
+                .nbtShort(this.nbtShort)
                 .nbtInt(this.nbtInt)
                 .nbtStrings(this.nbtStrings)
+                .nbtShorts(this.nbtShorts)
                 .nbtInts(this.nbtInts)
                 .slot(this.slot)
                 .priority(this.priority)
@@ -368,8 +382,10 @@ public class MenuItemOptions {
         private LoreAppendMode loreAppendMode;
 
         private String nbtString;
+        private String nbtShort;
         private String nbtInt;
         private List<String> nbtStrings = Collections.emptyList();
+        private List<String> nbtShorts = Collections.emptyList();
         private List<String> nbtInts = Collections.emptyList();
 
         private int slot;
@@ -526,6 +542,11 @@ public class MenuItemOptions {
             return this;
         }
 
+        public MenuItemOptionsBuilder nbtShort(final @Nullable String nbtShort) {
+            this.nbtShort = nbtShort;
+            return this;
+        }
+
         public MenuItemOptionsBuilder nbtInt(final @Nullable String nbtInt) {
             this.nbtInt = nbtInt;
             return this;
@@ -533,6 +554,11 @@ public class MenuItemOptions {
 
         public MenuItemOptionsBuilder nbtStrings(final @NotNull List<String> nbtStrings) {
             this.nbtStrings = nbtStrings;
+            return this;
+        }
+
+        public MenuItemOptionsBuilder nbtShorts(final @NotNull List<String> nbtShorts) {
+            this.nbtShorts = nbtShorts;
             return this;
         }
 

--- a/src/main/java/com/extendedclip/deluxemenus/nbt/NbtProvider.java
+++ b/src/main/java/com/extendedclip/deluxemenus/nbt/NbtProvider.java
@@ -15,6 +15,7 @@ public final class NbtProvider {
     private static Method getStringMethod;
     private static Method setStringMethod;
     private static Method setBooleanMethod;
+    private static Method setShortMethod;
     private static Method setIntMethod;
     private static Method removeTagMethod;
     private static Method hasTagMethod;
@@ -36,6 +37,7 @@ public final class NbtProvider {
             getStringMethod = compoundClass.getMethod(VersionConstants.GET_STRING_METHOD_NAME, String.class);
             setStringMethod = compoundClass.getMethod(VersionConstants.SET_STRING_METHOD_NAME, String.class, String.class);
             setBooleanMethod = compoundClass.getMethod(VersionConstants.SET_BOOLEAN_METHOD_NAME, String.class, boolean.class);
+            setShortMethod = compoundClass.getMethod(VersionConstants.SET_SHORT_METHOD_NAME, String.class, short.class);
             setIntMethod = compoundClass.getMethod(VersionConstants.SET_INTEGER_METHOD_NAME, String.class, int.class);
             removeTagMethod = compoundClass.getMethod(VersionConstants.REMOVE_TAG_METHOD_NAME, String.class);
             hasTagMethod = itemStackClass.getMethod(VersionConstants.HAS_TAG_METHOD_NAME);
@@ -116,6 +118,19 @@ public final class NbtProvider {
         return getString(itemCompound, key);
     }
 
+    public static ItemStack setShort(final ItemStack itemStack, final String key, final short value) {
+        if (itemStack == null) return null;
+        if (itemStack.getType() == Material.AIR) return null;
+
+        Object nmsItemStack = asNMSCopy(itemStack);
+        Object itemCompound = hasTag(nmsItemStack) ? getTag(nmsItemStack) : newNBTTagCompound();
+
+        setShort(itemCompound, key, value);
+        setTag(nmsItemStack, itemCompound);
+
+        return asBukkitCopy(nmsItemStack);
+    }
+
     public static ItemStack setInt(final ItemStack itemStack, final String key, final int value) {
         if (itemStack == null) return null;
         if (itemStack.getType() == Material.AIR) return null;
@@ -172,6 +187,13 @@ public final class NbtProvider {
     private static void setBoolean(final Object itemCompound, final String key, final boolean value) {
         try {
             setBooleanMethod.invoke(itemCompound, key, value);
+        } catch (IllegalAccessException | InvocationTargetException ignored) {
+        }
+    }
+
+    private static void setShort(final Object itemCompound, final String key, final short value) {
+        try {
+            setShortMethod.invoke(itemCompound, key, value);
         } catch (IllegalAccessException | InvocationTargetException ignored) {
         }
     }
@@ -299,6 +321,7 @@ public final class NbtProvider {
         private final static String GET_STRING_METHOD_NAME = getStringMethodName();
         private final static String SET_STRING_METHOD_NAME = setStringMethodName();
         private final static String SET_BOOLEAN_METHOD_NAME = setBooleanMethodName();
+        private final static String SET_SHORT_METHOD_NAME = setShortMethodName();
         private final static String SET_INTEGER_METHOD_NAME = setIntegerMethodName();
         private final static String REMOVE_TAG_METHOD_NAME = removeTagMethodName();
         private final static String HAS_TAG_METHOD_NAME = hasTagMethodName();
@@ -318,6 +341,11 @@ public final class NbtProvider {
         private static String setBooleanMethodName() {
             if (VersionHelper.HAS_OBFUSCATED_NAMES) return "a";
             return "setBoolean";
+        }
+
+        private static String setShortMethodName() {
+            if (VersionHelper.HAS_OBFUSCATED_NAMES) return "a";
+            return "setShort";
         }
 
         private static String setIntegerMethodName() {


### PR DESCRIPTION
This PR adds options for NBT short tags. I know it's not something that has common usage on Spigot or Paper servers, but I think some people who have hybrid Forge/Bukkit servers with the Pixelmon mod would like to see this feature added.

Example (requires [ChangeOutput](https://api.extendedclip.com/expansions/changeoutput/) and [PixelmonExtension](https://github.com/Neovitalism/PixelmonExtension) PlaceholderAPI expansions):

```
items:
  'slot_1':
    material: PIXELMON_PIXELMON_SPRITE
    nbt_strings:
    - 'form:%changeoutput_equals_input:{pixelmon_party_1_form}_matcher:None_ifmatch:_else:{pixelmon_party_1_form}%'
    - 'palette:%pixelmon_party_1_palette%'
    nbt_short: 'ndex:%pixelmon_party_1_dex_number%'
    slot: 11
    priority: 1
    display_name: "&e(&b%pixelmon_party_1_name%&e) &7| &bNivel %pixelmon_party_1_level%"
    lore:
    - ""
    - "&7Género: &b%pixelmon_party_1_gender%"
    - "&7Habilidad: &b%pixelmon_party_1_ability%"
    - "&7Naturaleza: &b%pixelmon_party_1_nature%"
    - "&7Tamaño: &b%pixelmon_party_1_growth%"
    - "&7Forma: &b%pixelmon_party_1_form%"
    - "&7Paleta: &b%pixelmon_party_1_palette%"
    click_commands:
      - '[close]'
      - '[openguimenu] shiny_modifier_slot_1_confirmation'
    view_requirement:
      requirements:
        pokemon_valido:
          type: "!string equals"
          input: "%pixelmon_party_1_name%"
          output: "No pokemon in that party slot."
```

![image](https://github.com/user-attachments/assets/abc57a45-7a72-478c-82dd-4dead4d7d363)