### PR TITLE
Custom sounds in actions & Fix for <1.21.3

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
+++ b/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
@@ -10,7 +10,6 @@ import com.extendedclip.deluxemenus.utils.StringUtils;
 import com.extendedclip.deluxemenus.utils.VersionHelper;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.Bukkit;
-import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -354,32 +353,16 @@ public class ClickActionTask extends BukkitRunnable {
             case BROADCAST_SOUND:
             case BROADCAST_WORLD_SOUND:
             case PLAY_SOUND:
-                final Sound sound;
+                String sound;
                 float volume = 1;
                 float pitch = 1;
 
                 if (!executable.contains(" ")) {
-                    try {
-                        sound = Sound.valueOf(executable.toUpperCase());
-                    } catch (final IllegalArgumentException exception) {
-                        DeluxeMenus.printStacktrace(
-                                "Sound name given for sound action: " + executable + ", is not a valid sound!",
-                                exception
-                        );
-                        break;
-                    }
+                    sound = executable;
                 } else {
                     String[] parts = executable.split(" ", 3);
 
-                    try {
-                        sound = Sound.valueOf(parts[0].toUpperCase());
-                    } catch (final IllegalArgumentException exception) {
-                        DeluxeMenus.printStacktrace(
-                                "Sound name given for sound action: " + parts[0] + ", is not a valid sound!",
-                                exception
-                        );
-                        break;
-                    }
+                    sound = parts[0];
 
                     if (parts.length == 3) {
                         try {
@@ -414,6 +397,8 @@ public class ClickActionTask extends BukkitRunnable {
                         );
                     }
                 }
+
+                sound = sound.toLowerCase().replace("_", ".");
 
                 switch (actionType) {
                     case BROADCAST_SOUND:


### PR DESCRIPTION
Add support for custom sounds in [sound], [broadcastsound] & [broadcastsoundworld]
Works as an alternative to #158 and closes #157 since we use a string representing the sound's namespace instead of a Sound.

This also means that if a sound's namespace is different from the Sound's name in Spigot's Sound Enum (now Interface), it won't work, though from what I've seen, aside from . being replaced by _ (which I took in account) and namespaces being fully lowercased, they all seem to be exactly the same so there shouldn't be any issues.
