### PR TITLE
fix: Adjust Grass Material for Minecraft 1.20.3+ Compatibility

### DIFF
--- a/src/main/resources/default_menu.yml
+++ b/src/main/resources/default_menu.yml
@@ -13,7 +13,7 @@ items:
     material: DIRT
     slot: 0
   'grass':
-    material: SHORT_GRASS
+    material: GRASS_BLOCK
     slot: 1
   'gravel':
     material: GRAVEL

--- a/src/main/resources/default_menu.yml
+++ b/src/main/resources/default_menu.yml
@@ -13,7 +13,7 @@ items:
     material: DIRT
     slot: 0
   'grass':
-    material: GRASS
+    material: SHORT_GRASS
     slot: 1
   'gravel':
     material: GRAVEL


### PR DESCRIPTION
When using the default_menu.yml example GUI the grass item does not load because the material was renamed from GRASS to SHORT_GRASS.

Do you think it is suitable to just rename it in the config or should I make it so that it is compatible for version below 1.20.3 too?