### PR TITLE
Added tab completion for all DeluxeMenus admin commands

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/command/subcommand/DumpCommand.java
+++ b/src/main/java/com/extendedclip/deluxemenus/command/subcommand/DumpCommand.java
@@ -1,37 +1,48 @@
 package com.extendedclip.deluxemenus.command.subcommand;
 
 import com.extendedclip.deluxemenus.DeluxeMenus;
+import com.extendedclip.deluxemenus.menu.Menu;
 import com.extendedclip.deluxemenus.utils.DumpUtils;
 import com.extendedclip.deluxemenus.utils.Messages;
 import net.kyori.adventure.text.event.ClickEvent;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static net.kyori.adventure.text.Component.text;
 
 public class DumpCommand extends SubCommand {
+
+    private static final String ADMIN_PERMISSION = "deluxemenus.admin";
 
     public DumpCommand(final @NotNull DeluxeMenus plugin) {
         super(plugin);
     }
 
     @Override
-    public void execute(final @NotNull CommandSender sender, final @NotNull List<String> args) {
-        if (!sender.hasPermission("deluxemenus.admin")) {
+    public @NotNull String getName() {
+        return "dump";
+    }
+
+    @Override
+    public void execute(final @NotNull CommandSender sender, final @NotNull List<String> arguments) {
+        if (!sender.hasPermission(ADMIN_PERMISSION)) {
             plugin.sms(sender, Messages.NO_PERMISSION);
             return;
         }
 
-        if (args.size() != 1) {
+        if (arguments.size() != 1) {
             plugin.sms(sender, Messages.WRONG_USAGE_DUMP_COMMAND);
             return;
         }
 
         String dump = "";
         try {
-            dump = DumpUtils.createDump(plugin, args.get(0));
+            dump = DumpUtils.createDump(plugin, arguments.get(0));
         } catch (final RuntimeException ignored) {
         }
 
@@ -51,5 +62,53 @@ public class DumpCommand extends SubCommand {
 
             plugin.sms(sender, Messages.DUMP_SUCCESS.message().append(link));
         });
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(final @NotNull CommandSender sender, final @NotNull List<String> arguments) {
+        if (!sender.hasPermission(ADMIN_PERMISSION)) {
+            return null;
+        }
+
+        if (arguments.isEmpty()) {
+            return List.of(getName());
+        }
+
+        if (arguments.size() > 2) {
+            return null;
+        }
+
+        if (arguments.size() == 1) {
+            if (arguments.get(0).isEmpty()) {
+                return List.of(getName());
+            }
+
+            final String firstArgument = arguments.get(0).toLowerCase();
+
+            if (getName().startsWith(firstArgument)) {
+                return List.of(getName());
+            }
+
+            return null;
+        }
+
+        final String firstArgument = arguments.get(0).toLowerCase();
+
+        if (!getName().equals(firstArgument)) {
+            return null;
+        }
+
+        final String secondArgument = arguments.get(1).toLowerCase();
+
+        final List<String> completions = new ArrayList<>(Menu.getAllMenuNames());
+        completions.add("config");
+
+        if (secondArgument.isEmpty()) {
+            return completions;
+        }
+
+        return completions.stream()
+                .filter(completion -> completion.startsWith(secondArgument))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/extendedclip/deluxemenus/command/subcommand/ExecuteCommand.java
+++ b/src/main/java/com/extendedclip/deluxemenus/command/subcommand/ExecuteCommand.java
@@ -148,10 +148,8 @@ public class ExecuteCommand extends SubCommand {
             return onlinePlayerNames;
         }
 
-        final List<String> result = onlinePlayerNames.stream()
-                .filter(playerName -> playerName.startsWith(arguments.get(1)))
+        return onlinePlayerNames.stream()
+                .filter(playerName -> playerName.toLowerCase().startsWith(secondArgument))
                 .collect(Collectors.toList());
-
-        return result;
     }
 }

--- a/src/main/java/com/extendedclip/deluxemenus/command/subcommand/ExecuteCommand.java
+++ b/src/main/java/com/extendedclip/deluxemenus/command/subcommand/ExecuteCommand.java
@@ -12,10 +12,12 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class ExecuteCommand extends SubCommand {
 
@@ -24,24 +26,29 @@ public class ExecuteCommand extends SubCommand {
     }
 
     @Override
-    public void execute(final @NotNull CommandSender sender, final @NotNull List<String> args) {
+    public @NotNull String getName() {
+        return "execute";
+    }
+
+    @Override
+    public void execute(final @NotNull CommandSender sender, final @NotNull List<String> arguments) {
         if (!sender.isOp()) {
             plugin.sms(sender, Messages.NO_PERMISSION);
             return;
         }
 
-        if (args.size() < 2) {
+        if (arguments.size() < 2) {
             plugin.sms(sender, Messages.WRONG_USAGE_EXECUTE_COMMAND);
             return;
         }
 
-        Player target = Bukkit.getPlayerExact(args.get(0));
+        Player target = Bukkit.getPlayerExact(arguments.get(0));
         if (target == null) {
-            plugin.sms(sender, Messages.PLAYER_IS_NOT_ONLINE.message().replaceText(PLAYER_REPLACER_BUILDER.replacement(args.get(1)).build()));
+            plugin.sms(sender, Messages.PLAYER_IS_NOT_ONLINE.message().replaceText(PLAYER_REPLACER_BUILDER.replacement(arguments.get(1)).build()));
             return;
         }
 
-        String executable = String.join(" ", args.subList(1, args.size()));
+        String executable = String.join(" ", arguments.subList(1, arguments.size()));
 
         ActionType type = ActionType.getByStart(executable);
 
@@ -90,5 +97,61 @@ public class ExecuteCommand extends SubCommand {
 
         plugin.sms(sender, Messages.ACTION_EXECUTED_FOR.message().replaceText(PLAYER_REPLACER_BUILDER.replacement(target.getName()).build()));
 
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(final @NotNull CommandSender sender, final @NotNull List<String> arguments) {
+        if (!sender.isOp()) {
+            return null;
+        }
+
+        if (arguments.isEmpty()) {
+            return List.of(getName());
+        }
+
+        if (arguments.size() > 2) {
+            return null;
+        }
+
+        if (arguments.size() == 1) {
+            if (arguments.get(0).isEmpty()) {
+                return List.of(getName());
+            }
+
+            final String firstArgument = arguments.get(0).toLowerCase();
+
+            if (getName().startsWith(firstArgument)) {
+                return List.of(getName());
+            }
+
+            return null;
+        }
+
+        final String firstArgument = arguments.get(0).toLowerCase();
+
+        if (!getName().equals(firstArgument)) {
+            return null;
+        }
+
+        final List<String> onlinePlayerNames = Bukkit.getOnlinePlayers()
+                .stream()
+                .map(Player::getName)
+                .collect(Collectors.toList());
+
+        if (onlinePlayerNames.isEmpty()) {
+            return null;
+        }
+
+        final String secondArgument = arguments.get(1).toLowerCase();
+
+        if (secondArgument.isEmpty()) {
+            return onlinePlayerNames;
+        }
+
+        final List<String> result = onlinePlayerNames.stream()
+                .filter(playerName -> playerName.startsWith(arguments.get(1)))
+                .collect(Collectors.toList());
+
+        return result;
     }
 }

--- a/src/main/java/com/extendedclip/deluxemenus/command/subcommand/HelpCommand.java
+++ b/src/main/java/com/extendedclip/deluxemenus/command/subcommand/HelpCommand.java
@@ -4,22 +4,49 @@ import com.extendedclip.deluxemenus.DeluxeMenus;
 import com.extendedclip.deluxemenus.utils.Messages;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public class HelpCommand extends SubCommand {
+
+    private static final String ADMIN_PERMISSION = "deluxemenus.admin";
 
     public HelpCommand(final @NotNull DeluxeMenus plugin) {
         super(plugin);
     }
 
     @Override
-    public void execute(final @NotNull CommandSender sender, final @NotNull List<String> args) {
-        if (sender.hasPermission("deluxemenus.admin")) {
+    public @NotNull String getName() {
+        return "help";
+    }
+
+    @Override
+    public void execute(final @NotNull CommandSender sender, final @NotNull List<String> arguments) {
+        if (sender.hasPermission(ADMIN_PERMISSION)) {
             plugin.sms(sender, Messages.HELP_ADMIN);
             return;
         }
 
         plugin.sms(sender, Messages.HELP);
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(final @NotNull CommandSender sender, final @NotNull List<String> arguments) {
+        if (arguments.size() > 1) {
+            return null;
+        }
+
+        if (arguments.isEmpty() || arguments.get(0).isEmpty()) {
+            return List.of(getName());
+        }
+
+        final String argument = arguments.get(0).toLowerCase();
+
+        if (!getName().startsWith(argument)) {
+            return null;
+        }
+
+        return List.of(getName());
     }
 }

--- a/src/main/java/com/extendedclip/deluxemenus/command/subcommand/OpenCommand.java
+++ b/src/main/java/com/extendedclip/deluxemenus/command/subcommand/OpenCommand.java
@@ -7,26 +7,37 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class OpenCommand extends SubCommand {
+
+    private static final String OPEN_COMMAND = "deluxemenus.open";
 
     public OpenCommand(final @NotNull DeluxeMenus plugin) {
         super(plugin);
     }
 
     @Override
-    public void execute(final @NotNull CommandSender sender, final @NotNull List<String> args) {
-        if (!sender.hasPermission("deluxemenus.open")) {
+    public @NotNull String getName() {
+        return "open";
+    }
+
+    @Override
+    public void execute(final @NotNull CommandSender sender, final @NotNull List<String> arguments) {
+        if (!sender.hasPermission(OPEN_COMMAND)) {
             plugin.sms(sender, Messages.NO_PERMISSION);
             return;
         }
 
         boolean player = (sender instanceof Player);
 
-        if (args.isEmpty()) {
+        if (arguments.isEmpty()) {
             plugin.sms(sender, Messages.WRONG_USAGE_OPEN_COMMAND);
             return;
         }
@@ -39,40 +50,40 @@ public class OpenCommand extends SubCommand {
         Player viewer;
         String placeholderPlayer = null;
 
-        if (args.size() == 2 && args.get(1).startsWith("-p:")) {
+        if (arguments.size() == 2 && arguments.get(1).startsWith("-p:")) {
             if (!sender.hasPermission("deluxemenus.placeholdersfor")) {
                 plugin.sms(sender, Messages.NO_PERMISSION_PLAYER_ARGUMENT);
                 return;
             }
 
-            placeholderPlayer = args.get(1).replace("-p:", "");
+            placeholderPlayer = arguments.get(1).replace("-p:", "");
 
-        } else if (args.size() >= 3 && args.get(2).startsWith("-p:")) {
+        } else if (arguments.size() >= 3 && arguments.get(2).startsWith("-p:")) {
             if (!sender.hasPermission("deluxemenus.placeholdersfor")) {
                 plugin.sms(sender, Messages.NO_PERMISSION_PLAYER_ARGUMENT);
                 return;
             }
 
-            placeholderPlayer = args.get(2).replace("-p:", "");
+            placeholderPlayer = arguments.get(2).replace("-p:", "");
         }
 
-        if (args.size() >= 2) {
+        if (arguments.size() >= 2) {
             if (placeholderPlayer == null) {
                 if (player && !sender.hasPermission("deluxemenus.open.others")) {
                     plugin.sms(sender, Messages.NO_PERMISSION);
                     return;
                 }
 
-                viewer = Bukkit.getPlayerExact(args.get(1));
+                viewer = Bukkit.getPlayerExact(arguments.get(1));
 
             } else {
-                if (args.size() >= 3) {
+                if (arguments.size() >= 3) {
                     if (!sender.hasPermission("deluxemenus.open.others")) {
                         plugin.sms(sender, Messages.NO_PERMISSION);
                         return;
                     }
 
-                    viewer = Bukkit.getPlayerExact(args.get(1));
+                    viewer = Bukkit.getPlayerExact(arguments.get(1));
 
                 } else {
                     if (!player) {
@@ -94,7 +105,7 @@ public class OpenCommand extends SubCommand {
         }
 
         if (viewer == null) {
-            plugin.sms(sender, Messages.PLAYER_IS_NOT_ONLINE.message().replaceText(PLAYER_REPLACER_BUILDER.replacement(args.get(1)).build()));
+            plugin.sms(sender, Messages.PLAYER_IS_NOT_ONLINE.message().replaceText(PLAYER_REPLACER_BUILDER.replacement(arguments.get(1)).build()));
             return;
         }
 
@@ -116,13 +127,112 @@ public class OpenCommand extends SubCommand {
             }
         }
 
-        Optional<Menu> menu = Menu.getMenuByName(args.get(0));
+        Optional<Menu> menu = Menu.getMenuByName(arguments.get(0));
 
         if (menu.isEmpty()) {
-            plugin.sms(sender, Messages.INVALID_MENU.message().replaceText(MENU_REPLACER_BUILDER.replacement(args.get(0)).build()));
+            plugin.sms(sender, Messages.INVALID_MENU.message().replaceText(MENU_REPLACER_BUILDER.replacement(arguments.get(0)).build()));
             return;
         }
 
         menu.get().openMenu(viewer, null, placeholder);
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(final @NotNull CommandSender sender, final @NotNull List<String> arguments) {
+        if (!sender.hasPermission(OPEN_COMMAND)) {
+            return null;
+        }
+
+        if (arguments.isEmpty()) {
+            return List.of(getName());
+        }
+
+        if (arguments.size() > 4) {
+            return null;
+        }
+
+        if (arguments.size() == 1) {
+            if (arguments.get(0).isEmpty()) {
+                return List.of(getName());
+            }
+
+            final String firstArgument = arguments.get(0).toLowerCase();
+
+            if (getName().startsWith(firstArgument)) {
+                return List.of(getName());
+            }
+
+            return null;
+        }
+
+        final String firstArgument = arguments.get(0).toLowerCase();
+
+        if (!getName().equals(firstArgument)) {
+            return null;
+        }
+
+        final Collection<String> menuNames = Menu.getAllMenuNames();
+
+        if (menuNames.isEmpty()) {
+            return null;
+        }
+
+        if (arguments.size() == 2) {
+            final String secondArgument = arguments.get(1).toLowerCase();
+
+            if (secondArgument.isEmpty()) {
+                return List.copyOf(menuNames);
+            }
+
+            return menuNames.stream()
+                    .filter(menuName -> menuName.toLowerCase().startsWith(secondArgument))
+                    .collect(Collectors.toList());
+        }
+
+        final List<String> onlinePlayerNames = Bukkit.getOnlinePlayers()
+                .stream()
+                .map(Player::getName)
+                .collect(Collectors.toList());
+
+        if (arguments.size() == 3) {
+            final String thirdArgument = arguments.get(2).toLowerCase();
+
+            if (thirdArgument.isEmpty()) {
+                return Stream.concat(onlinePlayerNames.stream(), Stream.of("-p:")).collect(Collectors.toList());
+            }
+
+            if (!thirdArgument.startsWith("-")) {
+                return onlinePlayerNames.stream()
+                        .filter(playerName -> playerName.startsWith(thirdArgument))
+                        .collect(Collectors.toList());
+            }
+
+            return onlinePlayerNames.stream()
+                    .map(playerName -> "-p:" + playerName)
+                    .filter(playerName -> playerName.startsWith(arguments.get(2)))
+                    .collect(Collectors.toList());
+        }
+
+        if (arguments.size() == 4) {
+            final String thirdArgument = arguments.get(2).toLowerCase();
+            final String fourthArgument = arguments.get(3).toLowerCase();
+
+            if (!thirdArgument.startsWith("-p:")) {
+                return null;
+            }
+
+            if (fourthArgument.isEmpty()) {
+                return onlinePlayerNames.stream()
+                        .map(playerName -> "-p:" + playerName)
+                        .collect(Collectors.toList());
+            }
+
+            return onlinePlayerNames.stream()
+                    .map(playerName -> "-p:" + playerName)
+                    .filter(playerName -> playerName.startsWith(arguments.get(3)))
+                    .collect(Collectors.toList());
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/extendedclip/deluxemenus/command/subcommand/OpenCommand.java
+++ b/src/main/java/com/extendedclip/deluxemenus/command/subcommand/OpenCommand.java
@@ -203,13 +203,13 @@ public class OpenCommand extends SubCommand {
 
             if (!thirdArgument.startsWith("-")) {
                 return onlinePlayerNames.stream()
-                        .filter(playerName -> playerName.startsWith(arguments.get(2)))
+                        .filter(playerName -> playerName.toLowerCase().startsWith(thirdArgument))
                         .collect(Collectors.toList());
             }
 
             return onlinePlayerNames.stream()
                     .map(playerName -> "-p:" + playerName)
-                    .filter(playerName -> playerName.startsWith(arguments.get(2)))
+                    .filter(playerName -> playerName.toLowerCase().startsWith(thirdArgument))
                     .collect(Collectors.toList());
         }
 
@@ -226,7 +226,7 @@ public class OpenCommand extends SubCommand {
             }
 
             return onlinePlayerNames.stream()
-                    .filter(playerName -> playerName.startsWith(arguments.get(3)))
+                    .filter(playerName -> playerName.toLowerCase().startsWith(fourthArgument))
                     .collect(Collectors.toList());
         }
 

--- a/src/main/java/com/extendedclip/deluxemenus/command/subcommand/OpenCommand.java
+++ b/src/main/java/com/extendedclip/deluxemenus/command/subcommand/OpenCommand.java
@@ -203,7 +203,7 @@ public class OpenCommand extends SubCommand {
 
             if (!thirdArgument.startsWith("-")) {
                 return onlinePlayerNames.stream()
-                        .filter(playerName -> playerName.startsWith(thirdArgument))
+                        .filter(playerName -> playerName.startsWith(arguments.get(2)))
                         .collect(Collectors.toList());
             }
 
@@ -222,13 +222,10 @@ public class OpenCommand extends SubCommand {
             }
 
             if (fourthArgument.isEmpty()) {
-                return onlinePlayerNames.stream()
-                        .map(playerName -> "-p:" + playerName)
-                        .collect(Collectors.toList());
+                return onlinePlayerNames;
             }
 
             return onlinePlayerNames.stream()
-                    .map(playerName -> "-p:" + playerName)
                     .filter(playerName -> playerName.startsWith(arguments.get(3)))
                     .collect(Collectors.toList());
         }

--- a/src/main/java/com/extendedclip/deluxemenus/command/subcommand/ReloadCommand.java
+++ b/src/main/java/com/extendedclip/deluxemenus/command/subcommand/ReloadCommand.java
@@ -5,18 +5,28 @@ import com.extendedclip.deluxemenus.menu.Menu;
 import com.extendedclip.deluxemenus.utils.Messages;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ReloadCommand extends SubCommand {
+
+    private static final String RELOAD_PERMISSION = "deluxemenus.reload";
 
     public ReloadCommand(final @NotNull DeluxeMenus plugin) {
         super(plugin);
     }
 
     @Override
-    public void execute(final @NotNull CommandSender sender, final @NotNull List<String> args) {
-        if (!sender.hasPermission("deluxemenus.reload")) {
+    public @NotNull String getName() {
+        return "reload";
+    }
+
+    @Override
+    public void execute(final @NotNull CommandSender sender, final @NotNull List<String> arguments) {
+        if (!sender.hasPermission(RELOAD_PERMISSION)) {
             plugin.sms(sender, Messages.NO_PERMISSION);
             return;
         }
@@ -26,20 +36,20 @@ public class ReloadCommand extends SubCommand {
             return;
         }
 
-        if (!args.isEmpty()) {
-            if (Menu.getMenuByName(args.get(0)).isEmpty()) {
-                plugin.sms(sender, Messages.INVALID_MENU.message().replaceText(MENU_REPLACER_BUILDER.replacement(args.get(0)).build()));
+        if (!arguments.isEmpty()) {
+            if (Menu.getMenuByName(arguments.get(0)).isEmpty()) {
+                plugin.sms(sender, Messages.INVALID_MENU.message().replaceText(MENU_REPLACER_BUILDER.replacement(arguments.get(0)).build()));
                 return;
             }
 
-            Menu.unload(plugin, args.get(0));
+            Menu.unload(plugin, arguments.get(0));
 
-            if (plugin.getConfiguration().loadGUIMenu(args.get(0))) {
-                plugin.sms(sender, Messages.MENU_RELOADED.message().replaceText(MENU_REPLACER_BUILDER.replacement(args.get(0)).build()));
+            if (plugin.getConfiguration().loadGUIMenu(arguments.get(0))) {
+                plugin.sms(sender, Messages.MENU_RELOADED.message().replaceText(MENU_REPLACER_BUILDER.replacement(arguments.get(0)).build()));
                 return;
             }
 
-            plugin.sms(sender, Messages.MENU_NOT_RELOADED.message().replaceText(MENU_REPLACER_BUILDER.replacement(args.get(0)).build()));
+            plugin.sms(sender, Messages.MENU_NOT_RELOADED.message().replaceText(MENU_REPLACER_BUILDER.replacement(arguments.get(0)).build()));
             return;
 
         }
@@ -60,5 +70,56 @@ public class ReloadCommand extends SubCommand {
         }
 
         plugin.sms(sender, Messages.MENUS_LOADED.message().replaceText(AMOUNT_REPLACER_BUILDER.replacement(String.valueOf(gLoaded)).build()));
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(final @NotNull CommandSender sender, final @NotNull List<String> arguments) {
+        if (!sender.hasPermission(RELOAD_PERMISSION)) {
+            return null;
+        }
+
+        if (arguments.isEmpty()) {
+            return List.of(getName());
+        }
+
+        if (arguments.size() > 2) {
+            return null;
+        }
+
+        if (arguments.size() == 1) {
+            if (arguments.get(0).isEmpty()) {
+                return List.of(getName());
+            }
+
+            final String firstArgument = arguments.get(0).toLowerCase();
+
+            if (getName().startsWith(firstArgument)) {
+                return List.of(getName());
+            }
+
+            return null;
+        }
+
+        final String firstArgument = arguments.get(0).toLowerCase();
+
+        if (!getName().equals(firstArgument)) {
+            return null;
+        }
+
+        final Collection<String> menuNames = Menu.getAllMenuNames();
+
+        if (menuNames.isEmpty()) {
+            return null;
+        }
+
+        final String secondArgument = arguments.get(1).toLowerCase();
+
+        if (secondArgument.isEmpty()) {
+            return List.copyOf(menuNames);
+        }
+
+        return menuNames.stream()
+                .filter(menuName -> menuName.toLowerCase().startsWith(secondArgument))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/extendedclip/deluxemenus/command/subcommand/SubCommand.java
+++ b/src/main/java/com/extendedclip/deluxemenus/command/subcommand/SubCommand.java
@@ -4,6 +4,7 @@ import com.extendedclip.deluxemenus.DeluxeMenus;
 import net.kyori.adventure.text.TextReplacementConfig;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -19,5 +20,9 @@ public abstract class SubCommand {
         this.plugin = plugin;
     }
 
-    public abstract void execute(final @NotNull CommandSender sender, final @NotNull List<String> args);
+    public abstract @NotNull String getName();
+
+    public abstract void execute(final @NotNull CommandSender sender, final @NotNull List<String> arguments);
+
+    public abstract @Nullable List<String> onTabComplete(final @NotNull CommandSender sender, final @NotNull List<String> arguments);
 }

--- a/src/main/java/com/extendedclip/deluxemenus/menu/Menu.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/Menu.java
@@ -105,6 +105,10 @@ public class Menu {
         return menus.size();
     }
 
+    public static @NotNull Set<String> getAllMenuNames() {
+        return menus.keySet();
+    }
+
     public static @NotNull Collection<Menu> getAllMenus() {
         return menus.values();
     }


### PR DESCRIPTION
- Added tab completion for all DeluxeMenus admin commands.
- Every option is case insensitive.

While every option in tab complete is case insensitive, that is not always true during execution.
The 2 instances of this happening that I could find are menu names and the `-p:` tag for the '/dm open' command. We might want to look into making both of those case insensitive in the future.

https://github.com/user-attachments/assets/c02625be-d042-4886-a18b-7c88f60dab33

Closes #139 

Tested on: Paper version 1.21.4-164-main@8eb8e44