### PR TITLE
add mmoitems as softdepend

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ name: DeluxeMenus
 main: com.extendedclip.deluxemenus.DeluxeMenus
 version: ${version}
 authors: [ HelpChat ]
-softdepend: [ PlaceholderAPI, Vault, HeadDatabase, ItemsAdder, Oraxen, ExecutableItems, ExecutableBlocks, Score, SimpleItemGenerator ]
+softdepend: [ PlaceholderAPI, Vault, HeadDatabase, ItemsAdder, Oraxen, ExecutableItems, ExecutableBlocks, Score, SimpleItemGenerator, MMOItems ]
 description: All in one inventory menu system
 commands:
   deluxemenus:


### PR DESCRIPTION
This PR addresses an issue where the MMOItems integration doesn't work properly for many users because DeluxeMenus loads before MMOItems.