### PR TITLE
Fix MMO-Items not working when item id contains colon(s).

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/hooks/MMOItemsHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/MMOItemsHook.java
@@ -35,7 +35,7 @@ public class MMOItemsHook implements ItemHook, SimpleCache {
             return cached.clone();
         }
 
-        String[] splitArgs = arguments[0].split(":");
+        String[] splitArgs = arguments[0].split(":", 2);
         if (splitArgs.length != 2) {
             return new ItemStack(Material.STONE, 1);
         }
@@ -70,7 +70,7 @@ public class MMOItemsHook implements ItemHook, SimpleCache {
         if (arguments.length == 0) {
             return false;
         }
-        String[] splitArgs = arguments[0].split(":");
+        String[] splitArgs = arguments[0].split(":", 2);
         if (splitArgs.length != 2) return false;
         return splitArgs[0].equalsIgnoreCase(MMOItems.getTypeName(item)) && splitArgs[1].equalsIgnoreCase(MMOItems.getID(item));
     }


### PR DESCRIPTION
Tested by a Discord user and confirmed to work.