### PR TITLE
Fix light_level being overwritten for LIGHT item.

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -399,7 +399,7 @@ public class MenuItem {
         }
 
         if (this.options.lightLevel().isPresent() && itemMeta instanceof BlockDataMeta) {
-            final BlockDataMeta blockDataMeta = (BlockDataMeta) itemStack.getItemMeta();
+            final BlockDataMeta blockDataMeta = (BlockDataMeta) itemMeta;
             final BlockData blockData = blockDataMeta.getBlockData(itemStack.getType());
             if (blockData instanceof Light) {
                 final Light light = (Light) blockData;
@@ -423,7 +423,6 @@ public class MenuItem {
                     }
 
                     blockDataMeta.setBlockData(light);
-                    itemStack.setItemMeta(blockDataMeta);
                 } catch (final Exception exception) {
                     plugin.printStacktrace(
                             "Invalid light level found for light block: " + parsedLightLevel,


### PR DESCRIPTION
Fix light_level being overwritten.

![image](https://github.com/user-attachments/assets/88be851f-5b54-46c2-9d75-b198dae5240d)
![image](https://github.com/user-attachments/assets/bbabb964-817a-49f1-ad65-207155ab6200)


Closes #197 

Tested with: Paper version 1.21.4-230-ver/1.21.4@af71568 (2025-05-11T20:55:55Z) (Implementing API version 1.21.4-R0.1-SNAPSHOT)
Tested ITEM_FLAGS to make sure they still apply as well.