### PR TITLE
Add [log] Action to Output Console Messages for Debugging/Testing, Closes #199

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/action/ActionType.java
+++ b/src/main/java/com/extendedclip/deluxemenus/action/ActionType.java
@@ -24,6 +24,7 @@ public enum ActionType {
       "- '[minibroadcast] <message>'"),
   MESSAGE("[message]", "Send a message to the menu viewer",
       "- [message] <message>"),
+  LOG("[log]", "Log a message to the console", "- [log] <level> <message>"),
   BROADCAST("[broadcast]", "Broadcast a message to the server", "- '[broadcast] <message>"),
   CHAT("[chat]", "Send a chat message as the player performing the action", "- '[chat] <message>"),
   OPEN_GUI_MENU("[openguimenu]", "Open a GUI menu", "- '[openguimenu] <menu-name>'"),

--- a/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
+++ b/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
@@ -11,6 +11,7 @@ import com.extendedclip.deluxemenus.utils.SoundUtils;
 import com.extendedclip.deluxemenus.utils.StringUtils;
 import com.extendedclip.deluxemenus.utils.VersionHelper;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.apache.commons.lang3.EnumUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -129,6 +130,20 @@ public class ClickActionTask extends BukkitRunnable {
 
             case MESSAGE:
                 player.sendMessage(StringUtils.color(executable));
+                break;
+
+            case LOG:
+                String[] logParts = executable.split(" ", 2);
+
+                Level logLevel;
+
+                try {
+                    logLevel = Level.parse(logParts[0].toUpperCase());
+                } catch (IllegalArgumentException e) {
+                    logLevel = Level.INFO;
+                }
+
+                plugin.getLogger().log(logLevel, String.format("[%s]: %s", holder.map(MenuHolder::getMenuName).orElse("Unknown Menu"), logParts[1]));
                 break;
 
             case BROADCAST:

--- a/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
+++ b/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
@@ -11,7 +11,6 @@ import com.extendedclip.deluxemenus.utils.SoundUtils;
 import com.extendedclip.deluxemenus.utils.StringUtils;
 import com.extendedclip.deluxemenus.utils.VersionHelper;
 import net.kyori.adventure.text.minimessage.MiniMessage;
-import org.apache.commons.lang3.EnumUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -133,17 +132,31 @@ public class ClickActionTask extends BukkitRunnable {
                 break;
 
             case LOG:
-                String[] logParts = executable.split(" ", 2);
+                final String[] logParts = executable.split(" ", 2);
 
-                Level logLevel;
-
-                try {
-                    logLevel = Level.parse(logParts[0].toUpperCase());
-                } catch (IllegalArgumentException e) {
-                    logLevel = Level.INFO;
+                if (logParts.length == 0 || logParts[0].isBlank()) {
+                    plugin.debug(DebugLevel.HIGHEST, Level.WARNING, "LOG command requires at least a message");
+                    break;
                 }
 
-                plugin.getLogger().log(logLevel, String.format("[%s]: %s", holder.map(MenuHolder::getMenuName).orElse("Unknown Menu"), logParts[1]));
+                Level logLevel;
+                String message;
+
+                if(logParts.length == 1) {
+                    logLevel = Level.INFO;
+                    message = logParts[0];
+                } else {
+                    message = logParts[1];
+
+                    try {
+                        logLevel = Level.parse(logParts[0].toUpperCase());
+                    } catch (IllegalArgumentException e) {
+                        logLevel = Level.INFO;
+                        plugin.debug(DebugLevel.HIGHEST, Level.WARNING, "Log level " + logParts[0] + " is not a valid log level! Using INFO instead.");
+                    }
+                }
+
+                plugin.getLogger().log(logLevel, String.format("[%s]: %s", holder.map(MenuHolder::getMenuName).orElse("Unknown Menu"), message));
                 break;
 
             case BROADCAST:


### PR DESCRIPTION
This PR introduces a new `[log]` action to enable logging custom messages directly to the console, which is particularly useful for debugging and monitoring player actions. The logged message is prefixed with the menus name which is logging it, or `Unknown Menu` if the holder is empty.

Syntax: ```[log] [level] [message]```

Parameters:
- `[level]`: can be any valid `java.util.logging.Level` (e.g., `INFO`, `WARNING`, `SEVERE`). If an invalid level is provided, it defaults to `INFO`.
- `[message]`: The message to output to console, supports placeholders.