### PR TITLE
Preserve comments and formatting in config.yml

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,8 @@ dependencies {
     compileOnly(libs.score)
     compileOnly(libs.sig)
 
-    compileOnly(libs.papi)    implementation(libs.nashorn)
+    compileOnly(libs.papi)
+    implementation(libs.nashorn)
     implementation(libs.adventure.platform)
     implementation(libs.adventure.minimessage)
     implementation(libs.bstats)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,12 +38,11 @@ dependencies {
     compileOnly(libs.score)
     compileOnly(libs.sig)
 
-    compileOnly(libs.papi)
-
-    implementation(libs.nashorn)
+    compileOnly(libs.papi)    implementation(libs.nashorn)
     implementation(libs.adventure.platform)
     implementation(libs.adventure.minimessage)
     implementation(libs.bstats)
+    implementation(libs.simple.yaml)
 
     compileOnly("org.jetbrains:annotations:23.0.0")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ papi = "2.11.6"
 score = "4.24.3.5"
 sig = "1.5.0"
 bstats = "3.1.0"
+simple-yaml = "1.8.4"
 
 # Implementation
 nashorn = "15.6"
@@ -33,6 +34,7 @@ mmoitems = { module = "net.Indyuce:MMOItems-API", version.ref = "mmoitems" }
 papi = { module = "me.clip:placeholderapi", version.ref = "papi" }
 score = { module = "com.github.Ssomar-Developement:SCore", version.ref = "score" }
 sig = { module = "io.github.valerashimchuck:simpleitemgenerator-api", version.ref = "sig" }
+simple-yaml = { module = "com.github.Carleslc.Simple-YAML:Simple-Yaml", version.ref = "simple-yaml" }
 
 # Implementation
 nashorn = { module = "org.openjdk.nashorn:nashorn-core", version.ref = "nashorn" }

--- a/src/main/java/com/extendedclip/deluxemenus/DeluxeMenus.java
+++ b/src/main/java/com/extendedclip/deluxemenus/DeluxeMenus.java
@@ -54,10 +54,9 @@ public class DeluxeMenus extends JavaPlugin {
     private VaultHook vaultHook;
 
     private ItemStack head;
-    private Map<String, ItemHook> itemHooks;
-
-    private final GeneralConfig generalConfig = new GeneralConfig(this);
+    private Map<String, ItemHook> itemHooks;    private final GeneralConfig generalConfig = new GeneralConfig(this);
     private DeluxeMenusConfig menuConfig;
+    private com.extendedclip.deluxemenus.config.CommentPreservingConfig commentPreservingConfig;
 
     @Override
     public void onLoad() {
@@ -71,10 +70,9 @@ public class DeluxeMenus extends JavaPlugin {
                 Level.WARNING,
                 "Could not setup a NMS hook for your server version! The following Item options will not work: nbt_int, nbt_ints, nbt_string and nbt_strings."
         );
-    }
-
-    @Override
+    }    @Override
     public void onEnable() {
+        this.commentPreservingConfig = new com.extendedclip.deluxemenus.config.CommentPreservingConfig(this);
         this.generalConfig.load();
 
         if (!hookIntoPlaceholderAPI()) {
@@ -215,6 +213,27 @@ public class DeluxeMenus extends JavaPlugin {
 
     public GeneralConfig getGeneralConfig() {
         return generalConfig;
+    }
+
+    /**
+     * Overrides the default saveConfig to use comment-preserving functionality
+     */
+    @Override
+    public void saveConfig() {
+        File configFile = new File(getDataFolder(), "config.yml");
+        if (configFile.exists()) {
+            // Use our comment preserving config implementation
+            org.simpleyaml.configuration.file.YamlFile yamlFile = commentPreservingConfig.load(configFile);
+            if (yamlFile != null) {
+                // Copy values from memory config to the yamlFile
+                commentPreservingConfig.copyValues(getConfig(), yamlFile, "");
+                // Save with comments preserved
+                commentPreservingConfig.save(yamlFile);
+                return;
+            }
+        }
+        // Fall back to default implementation if something goes wrong
+        super.saveConfig();
     }
 
     private boolean hookIntoPlaceholderAPI() {

--- a/src/main/java/com/extendedclip/deluxemenus/DeluxeMenus.java
+++ b/src/main/java/com/extendedclip/deluxemenus/DeluxeMenus.java
@@ -34,6 +34,7 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
+import java.io.File;
 
 import java.util.*;
 import java.util.function.Function;
@@ -53,8 +54,8 @@ public class DeluxeMenus extends JavaPlugin {
 
     private VaultHook vaultHook;
 
-    private ItemStack head;
-    private Map<String, ItemHook> itemHooks;    private final GeneralConfig generalConfig = new GeneralConfig(this);
+    private Map<String, ItemHook> itemHooks;
+    private final GeneralConfig generalConfig = new GeneralConfig(this);
     private DeluxeMenusConfig menuConfig;
     private com.extendedclip.deluxemenus.config.CommentPreservingConfig commentPreservingConfig;
 

--- a/src/main/java/com/extendedclip/deluxemenus/config/CommentPreservingConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/CommentPreservingConfig.java
@@ -1,0 +1,82 @@
+package com.extendedclip.deluxemenus.config;
+
+import com.extendedclip.deluxemenus.DeluxeMenus;
+import com.extendedclip.deluxemenus.utils.DebugLevel;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.simpleyaml.configuration.file.YamlFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+
+/**
+ * Handles YAML configuration operations with full comment preservation.
+ * This class uses Simple-YAML library to ensure comments keep their exact formatting.
+ */
+public class CommentPreservingConfig {
+    private final DeluxeMenus plugin;
+
+    public CommentPreservingConfig(@NotNull final DeluxeMenus plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Loads a YAML file with comment preservation
+     *
+     * @param file The file to load
+     * @return The loaded YamlFile, or null if an error occurred
+     */
+    public YamlFile load(@NotNull final File file) {
+        YamlFile yamlFile = new YamlFile(file);
+        try {
+            yamlFile.loadWithComments();
+            return yamlFile;
+        } catch (IOException e) {
+            plugin.debug(DebugLevel.HIGHEST, Level.SEVERE, "Could not read file: " + file.getName());
+            plugin.printStacktrace("Could not read file: " + file.getName(), e);
+            return null;
+        } catch (InvalidConfigurationException e) {
+            plugin.debug(DebugLevel.HIGHEST, Level.SEVERE, "Detected invalid configuration in file: " + file.getName());
+            plugin.printStacktrace("Detected invalid configuration in file: " + file.getName(), e);
+            return null;
+        }
+    }
+
+    /**
+     * Saves a YamlFile with preserved comments
+     *
+     * @param yamlFile The YamlFile to save
+     * @return true if the file was saved successfully, false otherwise
+     */
+    public boolean save(@NotNull final YamlFile yamlFile) {
+        try {
+            yamlFile.saveWithComments();
+            return true;
+        } catch (IOException e) {
+            plugin.debug(DebugLevel.HIGHEST, Level.SEVERE, "Could not save file: " + yamlFile.getFilePath());
+            plugin.printStacktrace("Could not save file: " + yamlFile.getFilePath(), e);
+            return false;
+        }
+    }
+    
+    /**
+     * Copies values from a ConfigurationSection to a YamlFile
+     *
+     * @param section The source ConfigurationSection
+     * @param yamlFile The target YamlFile
+     * @param parentPath The parent path for nested sections
+     */
+    public void copyValues(@NotNull final ConfigurationSection section, @NotNull final YamlFile yamlFile, @NotNull final String parentPath) {
+        for (String key : section.getKeys(false)) {
+            String path = parentPath.isEmpty() ? key : parentPath + "." + key;
+            
+            if (section.isConfigurationSection(key)) {
+                copyValues(section.getConfigurationSection(key), yamlFile, path);
+            } else {
+                yamlFile.set(path, section.get(key));
+            }
+        }
+    }
+}

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -49,6 +49,7 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
+import org.simpleyaml.configuration.file.YamlFile;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -95,6 +96,7 @@ public class DeluxeMenusConfig {
     private final String separator = File.separator;
     private final File menuDirectory;
     private final DeluxeMenus plugin;
+    private final CommentPreservingConfig commentPreservingConfig;
     private final List<String> exampleMenus = Arrays.asList("basics_menu", "advanced_menu", "requirements_menu"
             // more example menus here
     );
@@ -103,6 +105,7 @@ public class DeluxeMenusConfig {
         VALID_MATERIAL_PREFIXES.addAll(plugin.getItemHooks().values().stream().map(ItemHook::getPrefix).collect(Collectors.toList()));
 
         this.plugin = plugin;
+        this.commentPreservingConfig = new CommentPreservingConfig(plugin);
         menuDirectory = new File(this.plugin.getDataFolder() + separator + "gui_menus");
         try {
             if (menuDirectory.mkdirs()) {


### PR DESCRIPTION
Utilize Simple-YAML to load and save config.yml, ensuring that user comments and indentation remain intact after reloads and restarts. The plugin's reload command and functionality stay unchanged.