### PR TITLE
fix for textures not showing on player name heads

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/utils/SkullUtils.java
+++ b/src/main/java/com/extendedclip/deluxemenus/utils/SkullUtils.java
@@ -136,7 +136,10 @@ public class SkullUtils {
 
         final OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(playerName);
 
-        if (!VersionHelper.IS_SKULL_OWNER_LEGACY) {
+        if (VersionHelper.HAS_PLAYER_PROFILES && offlinePlayer.getPlayerProfile().getTextures().isEmpty()) {
+            // updates the Player Profile and populates textures for offline players - for some reason this doesn't populate when getting the Profile first time
+            headMeta.setOwnerProfile(offlinePlayer.getPlayerProfile().update().join());
+        } else if (!VersionHelper.IS_SKULL_OWNER_LEGACY) {
             headMeta.setOwningPlayer(offlinePlayer);
         } else {
             headMeta.setOwner(offlinePlayer.getName());


### PR DESCRIPTION
Closes #151 

Not sure why people are using player names instead of base64 textures
This only happens when the player names have to go through mojang api, for some reason the textures aren't updated within the initial call of Bukkit.getOfflinePlayer()