### PR TITLE
Adding eco as soft-depend to fix compatibility issue

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ name: DeluxeMenus
 main: com.extendedclip.deluxemenus.DeluxeMenus
 version: ${version}
 authors: [ HelpChat ]
-softdepend: [ PlaceholderAPI, Vault, HeadDatabase, ItemsAdder, Nexo, Oraxen, ExecutableItems, ExecutableBlocks, Score, SimpleItemGenerator, MMOItems ]
+softdepend: [ PlaceholderAPI, Vault, HeadDatabase, ItemsAdder, Nexo, Oraxen, ExecutableItems, ExecutableBlocks, Score, SimpleItemGenerator, MMOItems, eco ]
 description: All in one inventory menu system
 commands:
   deluxemenus:


### PR DESCRIPTION
eco by Auxilor is a library for the Eco series of plugins (EcoItems, EcoSkills, libreforge, EcoArmor, EcoJobs, EcoPets)

Since Nexo support was added due to Nexo shading Kotlin. It made incompatible DeluxeMenus with eco.

By adding eco as a soft depend it make eco load before DeluxeMenus and allow the plugin to run normally