### PR TITLE
Update Adventure API

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,8 +16,8 @@ bstats = "3.1.0"
 
 # Implementation
 nashorn = "15.6"
-adventure-platform = "4.4.0"
-adventure-minimessage = "4.21.0"
+adventure-platform = "4.4.1"
+adventure-minimessage = "4.24.0"
 
 [libraries]
 # Compile only


### PR DESCRIPTION
Fixes `[minimessage]` components having issues with `<click>` components for me and probably some other issues on 1.21.8