### PR TITLE
Added support for latest SCore API

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ oraxen = "1.190.0"
 mythiclib = "1.7.1-SNAPSHOT"
 mmoitems = "6.10-SNAPSHOT"
 papi = "2.11.6"
-score = "4.24.3.5"
+score = "5.25.3.9"
 sig = "1.5.0"
 bstats = "3.1.0"
 

--- a/src/main/java/com/extendedclip/deluxemenus/hooks/ExecutableBlocksHook.java
+++ b/src/main/java/com/extendedclip/deluxemenus/hooks/ExecutableBlocksHook.java
@@ -1,9 +1,12 @@
 package com.extendedclip.deluxemenus.hooks;
 
 import com.extendedclip.deluxemenus.cache.SimpleCache;
-import com.ssomar.score.api.ExecutableBlocksAPI;
+import com.ssomar.score.api.executableblocks.ExecutableBlocksAPI;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+
+import com.ssomar.score.api.executableblocks.config.ExecutableBlockInterface;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -20,9 +23,9 @@ public class ExecutableBlocksHook implements ItemHook, SimpleCache {
     }
 
     final ItemStack item = cache.computeIfAbsent(arguments[0], (id) -> {
-      final ItemStack result = ExecutableBlocksAPI.getExecutableBlock(arguments[0]);
+      final Optional<ExecutableBlockInterface> result = ExecutableBlocksAPI.getExecutableBlocksManager().getExecutableBlock(arguments[0]);
 
-      return (result == null) ? null : result.clone();
+      return result.map(executableBlockInterface -> executableBlockInterface.buildItem(1, Optional.empty())).orElse(null);
     });
 
     return (item == null) ? new ItemStack(Material.STONE) : item.clone();


### PR DESCRIPTION
Closes #250 

Only the API for ExecutableBlocks seems to have changed. API for ExecutableItems is the same.
I have not tested this change as I don't have either plugin and they are paid.