### PR TITLE
default max stack size insted of 64

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuItem.java
@@ -245,8 +245,9 @@ public class MenuItem {
             }
         }
 
-        if (amount > 64) {
-            amount = 64;
+        int maxStackSize = itemStack.getMaxStackSize();
+        if (amount > maxStackSize) {
+            amount = maxStackSize;
         }
 
         itemStack.setAmount(amount);


### PR DESCRIPTION
added default item stack amount instead of 64
like snowball is 16 and spy glass is 1