### PR TITLE
feat: add open_gui property for direct menu switching (category navig…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,56 @@ You can create GUI menus that open with custom commands that will show stats or 
 
 DeluxeMenus depends on [PlaceholderAPI](https://www.spigotmc.org/resources/placeholderapi.6245/).
 
+## Fork Changes
+
+### New Feature: `open_gui` — Direct Menu Switching (Category Navigation)
+
+This fork adds a new `open_gui` item property that allows menu items to directly open another menu when clicked — no `click_commands` needed. This makes it simple to build **category-style navigation** where players can switch between menus like tabs.
+
+#### Usage
+
+Add `open_gui` to any menu item, pointing to the target menu name:
+
+```yaml
+items:
+  'pvp_tab':
+    material: DIAMOND_SWORD
+    slot: 2
+    display_name: '&c&lPvP'
+    open_gui: 'pvp_menu'
+  'kits_tab':
+    material: CHEST
+    slot: 4
+    display_name: '&6&lKits'
+    open_gui: 'kits_menu'
+```
+
+#### How it works
+
+- When clicked, the item instantly opens the target menu
+- **Supports PlaceholderAPI** placeholders and arguments in the menu name
+- **Passes current arguments** from the source menu to the target menu automatically
+- Takes **priority over `click_commands`** — if `open_gui` is set and the target menu exists, it opens directly
+- Logs a warning to console if the target menu is not found
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `MenuItemOptions.java` | Added `openGui` field, getter, and builder method |
+| `DeluxeMenusConfig.java` | Parses `open_gui` from YAML item config |
+| `PlayerListener.java` | Handles `open_gui` on inventory click with placeholder/argument support |
+
+#### Example menus
+
+See the included example files demonstrating a full category system:
+- `category_menu_example.yml` — Main menu with 3 category tabs
+- `pvp_menu.yml` — PvP category (2 items)
+- `kits_menu.yml` — Kits category (1 item)
+- `settings_menu.yml` — Settings category (2 items)
+
+---
+
 ## Contribute
 If you would like to contribute towards DeluxeMenus should you take a look at our [Contributing file][contributing] for the ins and outs on how you can do that and what you need to keep in mind.
 

--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -640,7 +640,8 @@ public class DeluxeMenusConfig {
                     .enchantmentGlintOverride(c.getString(currentPath + "enchantment_glint_override", null))
                     .rarity(c.getString(currentPath + "rarity", null))
                     .tooltipStyle(c.getString(currentPath + "tooltip_style", null))
-                    .itemModel(c.getString(currentPath + "item_model", null));
+                    .itemModel(c.getString(currentPath + "item_model", null))
+                    .openGui(c.getString(currentPath + "open_gui", null));
 
             if (c.contains(currentPath + "model_data_component") && c.isConfigurationSection(currentPath + "model_data_component")) {
                 final ConfigurationSection modelDataComponent = c.getConfigurationSection(currentPath + "model_data_component");

--- a/src/main/java/com/extendedclip/deluxemenus/listener/PlayerListener.java
+++ b/src/main/java/com/extendedclip/deluxemenus/listener/PlayerListener.java
@@ -152,6 +152,17 @@ public class PlayerListener extends Listener {
             this.shiftCache.put(player.getUniqueId(), System.currentTimeMillis());
         }
 
+        if (item.options().openGui().isPresent()) {
+            final String targetMenuName = holder.setPlaceholdersAndArguments(item.options().openGui().get());
+            final Optional<Menu> targetMenu = Menu.getMenuByName(targetMenuName);
+            if (targetMenu.isPresent()) {
+                this.cache.put(player.getUniqueId(), System.currentTimeMillis());
+                targetMenu.get().openMenu(player, holder.getTypedArgs(), holder.getPlaceholderPlayer());
+                return;
+            }
+            plugin.getLogger().warning("open_gui target menu '" + targetMenuName + "' not found!");
+        }
+
         if (handleClick(player, holder, item.options().clickHandler(), item.options().clickRequirements())) {
             return;
         }

--- a/src/main/java/com/extendedclip/deluxemenus/menu/options/MenuItemOptions.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/options/MenuItemOptions.java
@@ -42,6 +42,7 @@ public class MenuItemOptions {
     private final String rarity;
     private final String tooltipStyle;
     private final String itemModel;
+    private final String openGui;
 
     private final Map<Enchantment, Integer> enchantments;
     private final List<PotionEffect> potionEffects;
@@ -105,6 +106,7 @@ public class MenuItemOptions {
         this.rarity = builder.rarity;
         this.tooltipStyle = builder.tooltipStyle;
         this.itemModel = builder.itemModel;
+        this.openGui = builder.openGui;
         this.enchantments = builder.enchantments;
         this.potionEffects = builder.potionEffects;
         this.bannerMeta = builder.bannerMeta;
@@ -220,6 +222,10 @@ public class MenuItemOptions {
 
     public @NotNull Optional<String> itemModel() {
         return Optional.ofNullable(itemModel);
+    }
+
+    public @NotNull Optional<String> openGui() {
+        return Optional.ofNullable(openGui);
     }
 
     public @NotNull Map<Enchantment, Integer> enchantments() {
@@ -377,6 +383,7 @@ public class MenuItemOptions {
                 .rarity(this.rarity)
                 .tooltipStyle(this.tooltipStyle)
                 .itemModel(this.itemModel)
+                .openGui(this.openGui)
                 .enchantments(this.enchantments)
                 .potionEffects(this.potionEffects)
                 .bannerMeta(this.bannerMeta)
@@ -431,6 +438,7 @@ public class MenuItemOptions {
         private String rarity;
         private String tooltipStyle;
         private String itemModel;
+        private String openGui;
 
         private Map<Enchantment, Integer> enchantments = Collections.emptyMap();
         private List<PotionEffect> potionEffects = Collections.emptyList();
@@ -571,6 +579,11 @@ public class MenuItemOptions {
 
         public MenuItemOptionsBuilder itemModel(final @Nullable String itemModel) {
             this.itemModel = itemModel;
+            return this;
+        }
+
+        public MenuItemOptionsBuilder openGui(final @Nullable String openGui) {
+            this.openGui = openGui;
             return this;
         }
 

--- a/src/main/resources/category_menu_example.yml
+++ b/src/main/resources/category_menu_example.yml
@@ -1,0 +1,54 @@
+#  DeluxeMenus Category Menu Example
+#  Demonstrates the open_gui feature for switching between menus like categories
+#=========================================================
+menu_title: '&8&lMain Menu'
+open_command: mainmenu
+register_command: true
+size: 27
+items:
+  # Glass pane fillers
+  'filler':
+    material: BLACK_STAINED_GLASS_PANE
+    display_name: ' '
+    slots:
+      - '0-1'
+      - '3'
+      - '5'
+      - '7-8'
+      - '9-17'
+  # Category buttons (top row)
+  'pvp_category':
+    material: DIAMOND_SWORD
+    slot: 2
+    display_name: '&c&lPvP'
+    lore:
+      - ''
+      - '&7Browse PvP arenas and modes'
+      - '&eClick to open!'
+    open_gui: 'pvp_menu'
+  'kits_category':
+    material: CHEST
+    slot: 4
+    display_name: '&6&lKits'
+    lore:
+      - ''
+      - '&7Select your favorite kit'
+      - '&eClick to open!'
+    open_gui: 'kits_menu'
+  'settings_category':
+    material: COMPARATOR
+    slot: 6
+    display_name: '&a&lSettings'
+    lore:
+      - ''
+      - '&7Customize your experience'
+      - '&eClick to open!'
+    open_gui: 'settings_menu'
+  # Info item
+  'info':
+    material: BOOK
+    slot: 22
+    display_name: '&b&lInfo'
+    lore:
+      - '&7Select a category above'
+      - '&7to get started!'

--- a/src/main/resources/kits_menu.yml
+++ b/src/main/resources/kits_menu.yml
@@ -1,0 +1,60 @@
+#  Kits Category Menu
+#=========================================================
+menu_title: '&8&lKits'
+open_command: kitsmenu
+register_command: true
+size: 27
+items:
+  # Navigation bar - highlight current category
+  'filler':
+    material: BLACK_STAINED_GLASS_PANE
+    display_name: ' '
+    slots:
+      - '0-1'
+      - '3'
+      - '5'
+      - '7-8'
+  'pvp_tab':
+    material: DIAMOND_SWORD
+    slot: 2
+    display_name: '&7&lPvP'
+    lore:
+      - '&eClick to switch!'
+    open_gui: 'pvp_menu'
+  'kits_tab':
+    material: CHEST
+    slot: 4
+    display_name: '&6&lKits'
+    lore:
+      - '&aCurrently viewing'
+    enchantments:
+      - 'UNBREAKING;1'
+    hide_enchantments: true
+  'settings_tab':
+    material: COMPARATOR
+    slot: 6
+    display_name: '&7&lSettings'
+    lore:
+      - '&eClick to switch!'
+    open_gui: 'settings_menu'
+  # Kit items
+  'warrior_kit':
+    material: DIAMOND_CHESTPLATE
+    slot: 20
+    display_name: '&b&lWarrior Kit'
+    lore:
+      - ''
+      - '&7Full diamond armor + sword'
+      - ''
+      - '&eClick to select!'
+    click_commands:
+      - '[close]'
+      - '[player] kit warrior'
+  # Back button
+  'back':
+    material: ARROW
+    slot: 18
+    display_name: '&f&lBack'
+    lore:
+      - '&7Return to main menu'
+    open_gui: 'category_menu_example'

--- a/src/main/resources/pvp_menu.yml
+++ b/src/main/resources/pvp_menu.yml
@@ -1,0 +1,74 @@
+#  PvP Category Menu
+#=========================================================
+menu_title: '&8&lPvP'
+open_command: pvpmenu
+register_command: true
+size: 27
+items:
+  # Navigation bar - highlight current category
+  'filler':
+    material: BLACK_STAINED_GLASS_PANE
+    display_name: ' '
+    slots:
+      - '0-1'
+      - '3'
+      - '5'
+      - '7-8'
+  'pvp_tab':
+    material: DIAMOND_SWORD
+    slot: 2
+    display_name: '&c&lPvP'
+    lore:
+      - '&aCurrently viewing'
+    enchantments:
+      - 'UNBREAKING;1'
+    hide_enchantments: true
+  'kits_tab':
+    material: CHEST
+    slot: 4
+    display_name: '&7&lKits'
+    lore:
+      - '&eClick to switch!'
+    open_gui: 'kits_menu'
+  'settings_tab':
+    material: COMPARATOR
+    slot: 6
+    display_name: '&7&lSettings'
+    lore:
+      - '&eClick to switch!'
+    open_gui: 'settings_menu'
+  # PvP items
+  'arena_1v1':
+    material: IRON_SWORD
+    slot: 19
+    display_name: '&c1v1 Arena'
+    lore:
+      - ''
+      - '&7Classic 1v1 duel arena'
+      - '&7Map: &fColosseum'
+      - ''
+      - '&eClick to join!'
+    click_commands:
+      - '[close]'
+      - '[player] arena join 1v1'
+  'arena_ffa':
+    material: GOLDEN_SWORD
+    slot: 21
+    display_name: '&6Free For All'
+    lore:
+      - ''
+      - '&7Fight everyone in the pit'
+      - '&7Map: &fWarzone'
+      - ''
+      - '&eClick to join!'
+    click_commands:
+      - '[close]'
+      - '[player] arena join ffa'
+  # Back button
+  'back':
+    material: ARROW
+    slot: 18
+    display_name: '&f&lBack'
+    lore:
+      - '&7Return to main menu'
+    open_gui: 'category_menu_example'

--- a/src/main/resources/settings_menu.yml
+++ b/src/main/resources/settings_menu.yml
@@ -1,0 +1,72 @@
+#  Settings Category Menu
+#=========================================================
+menu_title: '&8&lSettings'
+open_command: settingsmenu
+register_command: true
+size: 27
+items:
+  # Navigation bar - highlight current category
+  'filler':
+    material: BLACK_STAINED_GLASS_PANE
+    display_name: ' '
+    slots:
+      - '0-1'
+      - '3'
+      - '5'
+      - '7-8'
+  'pvp_tab':
+    material: DIAMOND_SWORD
+    slot: 2
+    display_name: '&7&lPvP'
+    lore:
+      - '&eClick to switch!'
+    open_gui: 'pvp_menu'
+  'kits_tab':
+    material: CHEST
+    slot: 4
+    display_name: '&7&lKits'
+    lore:
+      - '&eClick to switch!'
+    open_gui: 'kits_menu'
+  'settings_tab':
+    material: COMPARATOR
+    slot: 6
+    display_name: '&a&lSettings'
+    lore:
+      - '&aCurrently viewing'
+    enchantments:
+      - 'UNBREAKING;1'
+    hide_enchantments: true
+  # Settings items
+  'toggle_chat':
+    material: WRITABLE_BOOK
+    slot: 19
+    display_name: '&e&lToggle Chat'
+    lore:
+      - ''
+      - '&7Turn chat on or off'
+      - ''
+      - '&eClick to toggle!'
+    click_commands:
+      - '[player] togglechat'
+      - '[message] &aChat toggled!'
+  'toggle_scoreboard':
+    material: PAINTING
+    slot: 21
+    display_name: '&d&lToggle Scoreboard'
+    lore:
+      - ''
+      - '&7Show or hide the scoreboard'
+      - ''
+      - '&eClick to toggle!'
+    click_commands:
+      - '[player] togglescoreboard'
+      - '[message] &aScoreboard toggled!'
+  # Back button
+  'back':
+    material: ARROW
+    slot: 18
+    display_name: '&f&lBack'
+    lore:
+      - '&7Return to main menu'
+    open_gui: 'category_menu_example'


### PR DESCRIPTION
…ation)

- Added open_gui item property to MenuItemOptions (field, getter, builder)
- Parse open_gui from YAML config in DeluxeMenusConfig
- Handle open_gui on click in PlayerListener with placeholder/argument support
- Added example category menu files (main menu + 3 sub-menus)
- Updated README with feature documentation