### PR TITLE
fix(refresh): mark items so DupeFixer can catch them

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/MenuHolder.java
@@ -189,6 +189,12 @@ public class MenuHolder implements InventoryHolder {
 
                     ItemStack iStack = item.getItemStack(this);
 
+                    if (iStack == null) {
+                        continue;
+                    }
+
+                    iStack = plugin.getMenuItemMarker().mark(iStack);
+
                     int slot = item.options().slot();
 
                     if (slot >= menu.options().size()) {


### PR DESCRIPTION
`Menu#openMenu` stamps every `ItemStack` with `MenuItemMarker#mark` before placing it in the inventory, so `DupeFixer.onPickup` / `onDrop` and `Menu#cleanInventory` can recognize and remove a DeluxeMenus item that ever escapes the menu. `MenuHolder#refreshMenu` rebuilds the same stacks but skips that call. Any item served after a refresh (`[refresh]` action, `refresh_interval`, periodic update task) slips past the dupe fixer.

## Fix

Mirror the null-check + mark pattern already used in `Menu#openMenu`:

```diff
                 for (MenuItem item : active) {

                     ItemStack iStack = item.getItemStack(this);

+                    if (iStack == null) {
+                        continue;
+                    }
+
+                    iStack = plugin.getMenuItemMarker().mark(iStack);

                     int slot = item.options().slot();
```

## Demonstration

https://github.com/user-attachments/assets/0ec0ecbc-b661-4eb2-a7fa-44d2275e32dc

A companion plugin rewrites each menu item's lore every tick with its live PDC keys, so the marker state is observable in-game without dumping NBT.

Menu config:

```yml
menu_title: '&8Refresh sanitizes PDC'
open_command: demo
size: 27

items:
  diamond:
    material: DIAMOND
    slot: 13
    left_click_commands:
    - '[refresh]'
    right_click_commands:
    - '[openmenu] demo'
```

On `/demo`, the diamond's lore reads `deluxemenus:dm`.

- **Without this patch**: left-click flips the lore to `(no PDC keys)`. Right-click (`[openmenu]`) restores it, since `Menu#openMenu` already marks correctly.
- **With this patch**: the lore stays on `deluxemenus:dm` across any number of refreshes.
