### PR TITLE
Added Action Bar message ActionType

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/action/ActionType.java
+++ b/src/main/java/com/extendedclip/deluxemenus/action/ActionType.java
@@ -24,6 +24,7 @@ public enum ActionType {
       "- '[minibroadcast] <message>'"),
   MESSAGE("[message]", "Send a message to the menu viewer",
       "- [message] <message>"),
+  ACTION_BAR("[actionbar]", "Send a action bar message to the menu viewer", "- [actionbar] <message>"),
   LOG("[log]", "Log a message to the console", "- [log] <level> <message>"),
   BROADCAST("[broadcast]", "Broadcast a message to the server", "- '[broadcast] <message>"),
   CHAT("[chat]", "Send a chat message as the player performing the action", "- '[chat] <message>"),

--- a/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
+++ b/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
@@ -13,6 +13,8 @@ import com.extendedclip.deluxemenus.utils.SoundUtils;
 import com.extendedclip.deluxemenus.utils.StringUtils;
 import com.extendedclip.deluxemenus.utils.VersionHelper;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -133,7 +135,7 @@ public class ClickActionTask extends UniversalRunnable {
                 break;
 
             case ACTION_BAR:
-                player.sendActionBar(StringUtils.color(executable));
+                player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(StringUtils.color(executable)));
                 break;
 
             case LOG:

--- a/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
+++ b/src/main/java/com/extendedclip/deluxemenus/action/ClickActionTask.java
@@ -132,6 +132,10 @@ public class ClickActionTask extends UniversalRunnable {
                 player.sendMessage(StringUtils.color(executable));
                 break;
 
+            case ACTION_BAR:
+                player.sendActionBar(StringUtils.color(executable));
+                break;
+
             case LOG:
                 final String[] logParts = executable.split(" ", 2);
 


### PR DESCRIPTION
This PR adds a `[actionbar] <message>` action type for sending messages to the player's action bar.

Tested on Paper 1.21.8.

I'll follow-up with a wiki pr to document the addition (plus missing ones like `[log]`) once this is confirmed for merging.