### PR TITLE
Fix open_commands actions running after menu item render

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
+++ b/src/main/java/com/extendedclip/deluxemenus/config/DeluxeMenusConfig.java
@@ -35,6 +35,7 @@ import com.extendedclip.deluxemenus.utils.LocationUtils;
 import com.extendedclip.deluxemenus.utils.VersionHelper;
 import com.google.common.base.Enums;
 import com.google.common.primitives.Ints;
+import org.bukkit.Bukkit;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -1235,6 +1236,11 @@ public class DeluxeMenusConfig {
 
                         if (action.hasDelay()) {
                             actionTask.runTaskLater(plugin, action.getDelay(holder));
+                            continue;
+                        }
+
+                        if (Bukkit.isPrimaryThread()) {
+                            actionTask.run();
                             continue;
                         }
 

--- a/src/main/java/com/extendedclip/deluxemenus/menu/Menu.java
+++ b/src/main/java/com/extendedclip/deluxemenus/menu/Menu.java
@@ -304,6 +304,8 @@ public class Menu {
             return;
         }
 
+        this.options.openHandler().ifPresent(h -> h.onClick(holder));
+
         scheduler.runTaskAsynchronously(() -> {
 
             Set<MenuItem> activeItems = new HashSet<>();
@@ -345,8 +347,6 @@ public class Menu {
 
             holder.setMenuName(this.options.name());
             holder.setActiveItems(activeItems);
-
-            this.options.openHandler().ifPresent(h -> h.onClick(holder));
 
             String title = StringUtils.color(holder.setPlaceholdersAndArguments(this.options.title()));
 


### PR DESCRIPTION
## Issue

`open_commands`, used to reset meta state on menu open, were running one tick after menu open, while items were already being rendered with old state

this caused cases where `[meta]` values were reset correctly, but placeholders and `dynamic_amount` could still render stale values on menu open

## Fix

run `open_commands` before item rendering and execute `open_commands` actions immediately when already on main thread