### PR TITLE
Handle legacy NBT warning on data component versions

### DIFF
--- a/src/main/java/com/extendedclip/deluxemenus/DeluxeMenus.java
+++ b/src/main/java/com/extendedclip/deluxemenus/DeluxeMenus.java
@@ -63,6 +63,15 @@ public class DeluxeMenus extends JavaPlugin {
 
     @Override
     public void onLoad() {
+        if (VersionHelper.HAS_DATA_COMPONENTS) {
+            this.debug(
+                    DebugLevel.HIGHEST,
+                    Level.INFO,
+                    "Legacy NBT item options are not supported on data component versions. The following options are unavailable: nbt_int, nbt_ints, nbt_string and nbt_strings."
+            );
+            return;
+        }
+
         if (NbtProvider.isAvailable()) {
             this.debug(DebugLevel.HIGHEST, Level.INFO, "NMS hook has been setup successfully!");
             return;


### PR DESCRIPTION
On Minecraft versions using item data components, the legacy NBT hook is no longer applicable.

DeluxeMenus currently reports this as a warning:

`Could not setup a NMS hook for your server version!`

However, on data component versions this is expected behavior rather than a hook failure.

This change detects `VersionHelper.HAS_DATA_COMPONENTS` before checking the legacy NBT provider and reports the unsupported legacy NBT item options as an informational message instead.

This does not attempt to restore the legacy `nbt_int`, `nbt_ints`, `nbt_string`, or `nbt_strings` options on modern versions.

Related to #196.

This is separate from #290, which addresses CraftBukkit package resolution on Paper 26.x.